### PR TITLE
Change Vagrant bootstrapping to be able to run as root

### DIFF
--- a/Vagrant/.gitignore
+++ b/Vagrant/.gitignore
@@ -1,0 +1,1 @@
+.vagrant/

--- a/Vagrant/Vagrantfile
+++ b/Vagrant/Vagrantfile
@@ -24,7 +24,7 @@ Vagrant.configure(2) do |config|
   config.vm.network :forwarded_port, host: 3000, guest: 3000
   config.vm.network :forwarded_port, host: 8080, guest: 8080
   config.vm.network :forwarded_port, host: 4433, guest: 4433
-  config.vm.provision :shell, args: [installuser, hydrahead, gitrepo], privileged: false,
+  config.vm.provision :shell, args: [installuser, hydrahead, gitrepo], privileged: true,
     path: 'bootstrap.sh'
   config.vm.provision :shell, args:[installuser, hydrahead], run: 'always', privileged: false, inline: runserver
 end

--- a/Vagrant/Vagrantfile
+++ b/Vagrant/Vagrantfile
@@ -24,6 +24,6 @@ Vagrant.configure(2) do |config|
   config.vm.network :forwarded_port, host: 8080, guest: 8080
   config.vm.network :forwarded_port, host: 4433, guest: 4433
   config.vm.provision :shell, args: [hydrahead, gitrepo], privileged: false,
-    path: 'https://raw.githubusercontent.com/VTUL/InstallScripts/master/Vagrant/bootstrap.sh'
+    path: 'bootstrap.sh'
   config.vm.provision :shell, args:[hydrahead], run: 'always', privileged: false, inline: runserver
 end

--- a/Vagrant/Vagrantfile
+++ b/Vagrant/Vagrantfile
@@ -1,13 +1,14 @@
 # vi: set ft=ruby :
 
+installuser = "vagrant"
 hydrahead = "data-repo"
 gitrepo = "VTUL/" + hydrahead
 
 runserver = <<EOF
-cd "/home/vagrant/$1/"
+cd "/home/$1/$2/"
 bundle exec rake jetty:start
-PIDFILE=/home/vagrant/$1/tmp/pids/resque.pid BACKGROUND=yes QUEUE=* rake environment resque:work \
-  1> /home/vagrant/$1/log/resque.log 2> /home/vagrant/$1/log/resque.log
+PIDFILE=/home/$1/$2/tmp/pids/resque.pid BACKGROUND=yes QUEUE=* rake environment resque:work \
+  1> /home/$1/$2/log/resque.log 2> /home/$1/$2/log/resque.log
 bundle exec rails server --binding=0.0.0.0 --daemon
 echo "The server should be running at 127.0.0.1:3000"
 echo "The site exists in /home/vagrant/$1"
@@ -23,7 +24,7 @@ Vagrant.configure(2) do |config|
   config.vm.network :forwarded_port, host: 3000, guest: 3000
   config.vm.network :forwarded_port, host: 8080, guest: 8080
   config.vm.network :forwarded_port, host: 4433, guest: 4433
-  config.vm.provision :shell, args: [hydrahead, gitrepo], privileged: false,
+  config.vm.provision :shell, args: [installuser, hydrahead, gitrepo], privileged: false,
     path: 'bootstrap.sh'
-  config.vm.provision :shell, args:[hydrahead], run: 'always', privileged: false, inline: runserver
+  config.vm.provision :shell, args:[installuser, hydrahead], run: 'always', privileged: false, inline: runserver
 end

--- a/Vagrant/bootstrap.sh
+++ b/Vagrant/bootstrap.sh
@@ -6,11 +6,22 @@ set -o errexit
 echo "Version 1.0"
 
 # Vars
-basedir="/home/vagrant"
+installuser="ubuntu" # Name of user to install under (must already exist)
+hydrahead="data-repo" # Name of the Hydra head.
+gitrepo="VTUL/data-repo" # The git repository to pull changes from during setup.
+# Override installuser, hydrahead, and gitrepo via shell script arguments
+if [ $# -ge 1 ]; then
+  installuser="$1"
+fi
+if [ $# -ge 2 ]; then
+  hydrahead="$2"
+fi
+if [ $# -ge 3 ]; then
+  gitrepo="$3"
+fi
+basedir="/home/$installuser"
 fitsdir="$basedir/fits" # Where FITS will be installed.
-hydrahead="$1" # Name of the Hydra head. Supplied by the Vagrantfile
 hydradir="$basedir/$hydrahead" # Where the Hydra head will be located.
-gitrepo="$2" # The git repository to pull changes from during setup. Supplied by the Vagrantfile.
 
 fitsver="fits-0.6.2" # The version of FITS to install.
 rubyver="ruby2.2" # The version of Ruby to install.
@@ -66,7 +77,7 @@ bundle exec rake db:migrate
 # Download and configure Jetty
 bundle exec rake jetty:clean sufia:jetty:config
 
-# Pull from git. This fixes application configuration 
+# Pull from git. This fixes application configuration
 git init
 git remote add origin "https://github.com/$gitrepo.git"
 git fetch --all

--- a/Vagrant/bootstrap.sh
+++ b/Vagrant/bootstrap.sh
@@ -28,58 +28,60 @@ rubyver="ruby2.2" # The version of Ruby to install.
 railsver=">=4.2" # The version of Rails to install.
 sufiaver="6.0.0" # The version of Sufia to install.
 
+RUN_AS_INSTALLUSER="sudo -H -u $installuser"
+
 # Update packages
 cd "$basedir/"
-sudo apt-get update
-sudo apt-get upgrade -y
+apt-get update
+apt-get upgrade -y
 
 # Install Ruby
 # Brightbox also packages Passenger, which will be useful for production.
-sudo add-apt-repository -y ppa:brightbox/ruby-ng
-sudo apt-get update
-sudo apt-get install -y "$rubyver"
+add-apt-repository -y ppa:brightbox/ruby-ng
+apt-get update
+apt-get install -y "$rubyver"
 
 # Install FITS
-sudo apt-get install -y openjdk-7-jdk unzip
-mkdir -p "$fitsdir/"
+apt-get install -y openjdk-7-jdk unzip
+$RUN_AS_INSTALLUSER mkdir -p "$fitsdir/"
 cd "$fitsdir/"
-wget --quiet "http://projects.iq.harvard.edu/files/fits/files/$fitsver.zip"
-unzip -q "$fitsdir/$fitsver.zip"
-sudo chmod a+x "$fitsdir/$fitsver/fits.sh"
+$RUN_AS_INSTALLUSER wget --quiet "http://projects.iq.harvard.edu/files/fits/files/$fitsver.zip"
+$RUN_AS_INSTALLUSER unzip -q "$fitsdir/$fitsver.zip"
+chmod a+x "$fitsdir/$fitsver/fits.sh"
 cd "$basedir/"
 
 # Install ffmpeg
 # Instructions from the static builds link on this page: https://trac.ffmpeg.org/wiki/CompilationGuide/Ubuntu
-sudo add-apt-repository -y ppa:mc3man/trusty-media
-sudo apt-get update
-sudo apt-get install -y ffmpeg
+add-apt-repository -y ppa:mc3man/trusty-media
+apt-get update
+apt-get install -y ffmpeg
 
 # Install nodejs from Nodesource
-curl -sL https://deb.nodesource.com/setup | sudo bash -
-sudo apt-get install -y nodejs
+curl -sL https://deb.nodesource.com/setup | bash -
+apt-get install -y nodejs
 
 # Install Redis, ImageMagick, PhantomJS, and Libre Office
-sudo apt-get install -y redis-server imagemagick phantomjs libreoffice
+apt-get install -y redis-server imagemagick phantomjs libreoffice
 
 # Create Hydra head
-sudo apt-get install -y "$rubyver-dev" git sqlite3 libsqlite3-dev zlib1g-dev build-essential
-sudo gem install --no-document rails -v "$railsver"
-rails new "$hydrahead" "$hydradir"
+apt-get install -y "$rubyver-dev" git sqlite3 libsqlite3-dev zlib1g-dev build-essential
+gem install --no-document rails -v "$railsver"
+$RUN_AS_INSTALLUSER rails new "$hydrahead" "$hydradir"
 
 # Add and set up Sufia
 cd "$hydradir/"
-echo "gem 'sufia', '$sufiaver'" >> "$hydradir/Gemfile"
-echo "gem 'kaminari', github: 'jcoyne/kaminari', branch: 'sufia'" >> "$hydradir/Gemfile"
-bundle install
-rails generate sufia:install -f
-bundle exec rake db:migrate
+$RUN_AS_INSTALLUSER echo "gem 'sufia', '$sufiaver'" >> "$hydradir/Gemfile"
+$RUN_AS_INSTALLUSER echo "gem 'kaminari', github: 'jcoyne/kaminari', branch: 'sufia'" >> "$hydradir/Gemfile"
+$RUN_AS_INSTALLUSER bundle install
+$RUN_AS_INSTALLUSER rails generate sufia:install -f
+$RUN_AS_INSTALLUSER bundle exec rake db:migrate
 
 # Download and configure Jetty
-bundle exec rake jetty:clean sufia:jetty:config
+$RUN_AS_INSTALLUSER bundle exec rake jetty:clean sufia:jetty:config
 
 # Pull from git. This fixes application configuration
-git init
-git remote add origin "https://github.com/$gitrepo.git"
-git fetch --all
-git reset --hard origin/master
-bundle install
+$RUN_AS_INSTALLUSER git init
+$RUN_AS_INSTALLUSER git remote add origin "https://github.com/$gitrepo.git"
+$RUN_AS_INSTALLUSER git fetch --all
+$RUN_AS_INSTALLUSER git reset --hard origin/master
+$RUN_AS_INSTALLUSER bundle install

--- a/Vagrant/bootstrap.sh
+++ b/Vagrant/bootstrap.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -o errexit
+set -x -o errexit
 
 # For Ubuntu Server 14_04
 # Installs the default Sufia application and all of it's dependencies.


### PR DESCRIPTION
AWS shell provisioning via userdata runs as root when it executes.  To be able to share the bootstrap.sh script across Vagrant and AWS, I've edited the Vagrantfile and bootstrap.sh scripts to they expect the bootstrap.sh script to run as root.  I've tested and the script still works under Vagrant.

I also made some other minor changes, which are reflected in the commit messages.
