### PR TITLE
Use Java 8 as default JDK instead of Java 7.

### DIFF
--- a/Vagrant/bootstrap.sh
+++ b/Vagrant/bootstrap.sh
@@ -41,8 +41,15 @@ add-apt-repository -y ppa:brightbox/ruby-ng
 apt-get update
 apt-get install -y "$rubyver"
 
+# Install Java 8 and make it the default Java
+add-apt-repository -y ppa:webupd8team/java
+apt-get update -y
+echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections
+apt-get install -y oracle-java8-installer
+update-java-alternatives -s java-8-oracle
+
 # Install FITS
-apt-get install -y openjdk-7-jdk unzip
+apt-get install -y unzip
 $RUN_AS_INSTALLUSER mkdir -p "$fitsdir/"
 cd "$fitsdir/"
 $RUN_AS_INSTALLUSER wget --quiet "http://projects.iq.harvard.edu/files/fits/files/$fitsver.zip"


### PR DESCRIPTION
Sufia 6.2.0 brought in an explict requirement for Java 8 for the
bundled hydra-jetty.  Fedora 4.2.0 also now requires Java 8.
It was decided we should move to using Java 8 as the default JDK.

This update uses Oracle Java 8 instead of OpenJDK 8, because
currently Ubuntu Trusty does not have any OpenJDK 8 packages
available in its main repositories or in backports.  (Utopic
Unicorn onwards have OpenJDK 8 packages, so we'll have to wait
until the next Ubuntu LTS release to avail ourselves of those
packages.  For now, we use the Oracle Java 8 packages via the
webupd8team PPA.)

We also make Java 8 the default JDK via alternatives.  Previously,
FITS installed Java 7.  According to the FITS documentation, FITS
should work with Java 6 and up.
