### PR TITLE
Automate the data-repo README steps.

### DIFF
--- a/Vagrant/bootstrap.sh
+++ b/Vagrant/bootstrap.sh
@@ -92,3 +92,37 @@ $RUN_AS_INSTALLUSER git remote add origin "https://github.com/$gitrepo.git"
 $RUN_AS_INSTALLUSER git fetch --all
 $RUN_AS_INSTALLUSER git reset --hard origin/master
 $RUN_AS_INSTALLUSER bundle install
+
+# Setup the application
+
+# 1. Create a migration: rails generate migration CreateDoiRequests
+$RUN_AS_INSTALLUSER bundle exec rails generate migration CreateDoiRequests
+DOI_MIGRATION_FILE=`find db/migrate -type f -name '*_create_doi_requests.rb'|sort|tail -1`
+# 2. Replace the contents of the new migration with this gist: https://gist.github.com/tingtingjh/ab35348f493d565cdcc8
+$RUN_AS_INSTALLUSER cat > $DOI_MIGRATION_FILE <<GIST
+class CreateDoiRequests < ActiveRecord::Migration
+  def change
+    create_table :doi_requests do |t|
+      t.string "collection_id"
+      t.string "ezid_doi", default: "doi:pending", null: false
+      t.string "asset_type", default: "Collection", null: false
+      t.boolean "completed", default: false
+      t.timestamps null: false
+    end
+    add_index :doi_requests, :ezid_doi
+    add_index :doi_requests, :collection_id
+  end
+end
+GIST
+# 3. Generate Role model: rails generate roles
+$RUN_AS_INSTALLUSER bundle exec rails generate roles
+# 4. Remove the before filter added to app/controllers/application_controller.rb
+$RUN_AS_INSTALLUSER sed -i '/^  before_filter do$/,/^  end$/d' app/controllers/application_controller.rb
+# 5. Migrate
+$RUN_AS_INSTALLUSER bundle exec rake db:migrate
+# 6. Create default roles and an admin user
+$RUN_AS_INSTALLUSER bundle exec rake datarepo:setup_defaults
+# 7. Install Orcid
+$RUN_AS_INSTALLUSER bundle exec rails generate orcid:install --skip-application-yml
+# 8. Revert changes already incorporated
+$RUN_AS_INSTALLUSER git checkout ./app/models/user.rb ./config/routes.rb


### PR DESCRIPTION
Currently, the bootstrap.sh script installs the OS prerequisites and
the data-repo application.  The user must then run some post-install
commands to finish setting up the application.  These are listed in the
README file for the VTUL/data-repo repository on GitHub.

These changes put all the README steps except the final one (running
the CAS_extras.sh script) into the bootstrap.sh script itself.  There
should no longer be a need to run these commands separately.
