### PR TITLE
Allow larger uploads in Nginx

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,12 +140,12 @@ Several ports in the running VM are made accessible on the local machine.
 Accessing the local port in a Web browser will actually result in the forwarded
 port being accessed on the VM. These ports are as follows:
 
-Local | VM | Description
------ | -- | -----------
-8983 | 8983 | Solr services
-8888 | 8080 | Tomcat (Fedora 4)
-8080 | 80 | Data Repository (HTTP)
-4443 | 443 | Data Respository (HTTPS)
+Local | VM   | Description
+----- | ---- | -----------
+8983  | 8983 | Solr services
+8888  | 8080 | Tomcat (Fedora 4)
+8080  | 80   | Data Repository (HTTP)
+4443  | 443  | Data Respository (HTTPS)
 
 To access the Solr admin page in the VM from the local machine you would access
 this URL: `http://localhost:8983/solr`

--- a/install_sufia_application.sh
+++ b/install_sufia_application.sh
@@ -70,6 +70,7 @@ cat > $TMPFILE <<HereDoc
 server {
     listen 80;
     listen 443 ssl;
+    client_max_body_size 200M;
     root ${HYDRA_HEAD_DIR}/public;
     passenger_enabled on;
     passenger_app_env ${APP_ENV};


### PR DESCRIPTION
Configure Nginx to allow uploads up to 200 MB via the
client_max_body_size directive.
