### PR TITLE
Allow more ORCID settings to be supplied for production installs.

### DIFF
--- a/install_sufia_application.sh
+++ b/install_sufia_application.sh
@@ -120,12 +120,12 @@ $RUN_AS_INSTALLUSER bundle exec rake datarepo:setup_defaults
 # Application Deployment steps.
 if [ "$APP_ENV" = "production" ]; then
     $RUN_AS_INSTALLUSER bundle install --deployment --without development test
-    # Deploy production ORCID secrets from ${BOOTSTRAP_DIR}/files/orcid_secrets if they exist
-    if [ -f ${BOOTSTRAP_DIR}/files/orcid_secrets ]; then
-      NEW_ORCID_APP_ID=$(grep ORCID_APP_ID ${BOOTSTRAP_DIR}/files/orcid_secrets)
-      NEW_ORCID_APP_SECRET=$(grep ORCID_APP_SECRET ${BOOTSTRAP_DIR}/files/orcid_secrets)
-      $RUN_AS_INSTALLUSER sed -i "s/ORCID_APP_ID: 0000-0000-0000-0000/$NEW_ORCID_APP_ID/" "$HYDRA_HEAD_DIR/config/application.yml"
-      $RUN_AS_INSTALLUSER sed -i "s/ORCID_APP_SECRET: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX/$NEW_ORCID_APP_SECRET/" "$HYDRA_HEAD_DIR/config/application.yml"
+    # Deploy production ORCID secrets from ${BOOTSTRAP_DIR}/files/orcid_secrets if they exist unless installing via Vagrant
+    if [ -f ${BOOTSTRAP_DIR}/files/orcid_secrets -a $PLATFORM != "vagrant" ]; then
+      # Remove any existing active ORCID settings from application.yml
+      $RUN_AS_INSTALLUSER sed -i -r '/^[[:space:]]*ORCID_.*$/d' "$HYDRA_HEAD_DIR/config/application.yml"
+      # Append contents of ${BOOTSTRAP_DIR}/files/orcid_secrets to application.yml
+      $RUN_AS_INSTALLUSER cat "${BOOTSTRAP_DIR}/files/orcid_secrets" >> "$HYDRA_HEAD_DIR/config/application.yml"
     else
       echo 'Warning: No production orcid_secrets file supplied; using defaults!'
     fi


### PR DESCRIPTION
The previous handling of RAILS_ENV "production" ORCID settings allowed
only the ORCID_APP_ID and ORCID_APP_SECRET to be specified during
installation.  Unfortunately, this was incorrect as it still meant that
the ORCID Sandbox URLs were being used by default in ORCID OAuth API
calls.

This commit generalises the method of providing ORCID settings for
RAILS_ENV "production" installs.  In that case, now, any existing ORCID
settings are first removed from config/application.yml and then the
contents of files/orcid_secrets are appended to it (in effect replacing
any ORCID settings with the ones in files/orcid_secrets).

The files/orcid_secrets file is present on the bootstrapping system
being used to install and contains valid YAML ORCID settings
appropriate for production use.  The following settings should be
present: ORCID_APP_ID; ORCID_APP_SECRET; ORCID_SITE_URL;
ORCID_TOKEN_URL; ORCID_REMOTE_SIGNIN_URL; and ORCID_AUTHORIZE_URL

For the latter four, these are appropriate settings to point to the
ORCID production API URLs:
- ORCID_SITE_URL: http://api.orcid.org
- ORCID_TOKEN_URL: https://api.orcid.org/oauth/token
- ORCID_REMOTE_SIGNIN_URL: https://orcid.org/signin/auth.json
- ORCID_AUTHORIZE_URL: https://orcid.org/oauth/authorize
