### PR TITLE
Use PostgreSQL as the database adapter

### DIFF
--- a/bootstrap_server.sh
+++ b/bootstrap_server.sh
@@ -31,9 +31,6 @@ DEBIAN_FRONTEND=noninteractive apt-get -y -o Dpkg::Options::="--force-confdef" -
 # Install Fedora 4
 ${SCRIPTS_DIR}/install_fedora4.sh $PLATFORM $SCRIPTS_DIR
 
-# Install Sufia Data-Repo application
-${SCRIPTS_DIR}/install_sufia_application.sh $PLATFORM $SCRIPTS_DIR
-
 # Install and configure Postfix to send e-mail
 echo "postfix postfix/mailname string $SERVER_HOSTNAME" | debconf-set-selections
 echo "postfix postfix/main_mailer_type string 'Internet Site'" | debconf-set-selections
@@ -62,6 +59,9 @@ inet_interfaces = localhost
 inet_protocols = ipv4
 POSTFIX_CONF
 service postfix restart
+
+# Install Sufia Data-Repo application
+${SCRIPTS_DIR}/install_sufia_application.sh $PLATFORM $SCRIPTS_DIR
 
 # Install Solr
 ${SCRIPTS_DIR}/install_solr.sh $PLATFORM $SCRIPTS_DIR
@@ -93,7 +93,7 @@ fi
 
 start() {
   cd "${HYDRA_HEAD_DIR}"
-  sudo -H -u $INSTALL_USER bundle exec resque-pool --daemon --environment $APP_ENV --pidfile \$RESQUE_POOL_PIDFILE
+  sudo -H -u $INSTALL_USER RAILS_ENV=${APP_ENV} bundle exec resque-pool --daemon --environment $APP_ENV --pidfile \$RESQUE_POOL_PIDFILE
 }
 
 stop() {

--- a/config.sh
+++ b/config.sh
@@ -36,5 +36,6 @@ JDK_HOME="/usr/lib/jvm/java-8-oracle"
 FITS_PACKAGE="fits-0.6.2" # The version of FITS to install.
 RUBY_PACKAGE="ruby2.2" # The version of Ruby to install.
 RAILS_VERSION="~> 4.2" # The version of Rails to install.
-SUFIA_VERSION="6.2.0" # The version of Sufia to install.
 RUN_AS_SOLR_USER="sudo -H -u $SOLR_USER"
+POSTGRESQL_COMMAND="sudo -i -u postgres"
+DB_PASS="changeme"

--- a/install_postgresql.sh
+++ b/install_postgresql.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+# Install PostgreSQL
+
+# Read settings and environmental overrides
+# $1 = platform (aws or vagrant); $2 = path to install scripts
+[ -f "${2}/config.sh" ] && . "${2}/config.sh"
+[ -f "${2}/config_${1}.sh" ] && . "${2}/config_${1}.sh"
+
+cd "$INSTALL_DIR"
+
+apt-get install -y postgresql libpq-dev
+$POSTGRESQL_COMMAND psql -c "CREATE USER ${INSTALL_USER} WITH PASSWORD '${DB_PASS}';"
+$POSTGRESQL_COMMAND psql -c "CREATE DATABASE datarepo WITH OWNER ${INSTALL_USER} ENCODING 'UTF8';"
+
+# Create new config/database.yml that uses PostgreSQL as a DB
+cat <<EOF > "${HYDRA_HEAD_DIR}/config/database.yml"
+${APP_ENV}:
+  adapter: postgresql
+  encoding: UTF8
+  database: datarepo
+  username: ${INSTALL_USER}
+  password: ${DB_PASS}
+EOF


### PR DESCRIPTION
Install PostgreSQL and use it as the database adapter.  This required
some change in the order in which things are installed.  As part of
that, the installation of gems was modified after scrutinising the
existing approach.  Now there is only a single "bundle install".

Note that the existing install_postgresql.sh approach is to assume a
PostgreSQL setup where connections are made locally via a Unix domain
socket for performance.

Also, install_postgresql.sh is called from install_sufia_application.sh
because the PostgreSQL installation touches the application file
database.yml.
