### PR TITLE
Install ClamAV

### DIFF
--- a/bootstrap_server.sh
+++ b/bootstrap_server.sh
@@ -60,6 +60,9 @@ inet_protocols = ipv4
 POSTFIX_CONF
 service postfix restart
 
+# Install ClamAV
+${SCRIPTS_DIR}/install_clamav.sh $PLATFORM $SCRIPTS_DIR
+
 # Install Sufia Data-Repo application
 ${SCRIPTS_DIR}/install_sufia_application.sh $PLATFORM $SCRIPTS_DIR
 

--- a/install_clamav.sh
+++ b/install_clamav.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# Install ClamAV
+
+# Read settings and environmental overrides
+# $1 = platform (aws or vagrant); $2 = path to install scripts
+[ -f "${2}/config.sh" ] && . "${2}/config.sh"
+[ -f "${2}/config_${1}.sh" ] && . "${2}/config_${1}.sh"
+
+cd "$INSTALL_DIR"
+apt-get install -y clamav libclamav-dev


### PR DESCRIPTION
Install ClamAV for Sufia virus checking integration to work.  We also
install the ClamAV development libraries so the "clamav" Gem can be
built.
