### PR TITLE
Support setting of production EZ-ID DOI credentials

### DIFF
--- a/install_sufia_application.sh
+++ b/install_sufia_application.sh
@@ -138,6 +138,17 @@ if [ "$APP_ENV" = "production" ]; then
     else
       echo 'Warning: No production orcid_secrets file supplied; using defaults!'
     fi
+    # Deploy production EZ-ID DOI settings from ${BOOTSTRAP_DIR}/files/ezid_secrets if they exist unless installing via Vagrant
+    if [ -f ${BOOTSTRAP_DIR}/files/ezid_secrets -a $PLATFORM != "vagrant" ]; then
+      EZID_SHOULDER=$(grep config.default_shoulder ${BOOTSTRAP_DIR}/files/ezid_secrets) && \
+        $RUN_AS_INSTALLUSER sed -i "/config.default_shoulder/ c\  $EZID_SHOULDER" "$HYDRA_HEAD_DIR/config/initializers/ezid.rb"
+      EZID_USER=$(grep config.user ${BOOTSTRAP_DIR}/files/ezid_secrets) && \
+        $RUN_AS_INSTALLUSER sed -i "/config.user/ c\  $EZID_USER" "$HYDRA_HEAD_DIR/config/initializers/ezid.rb"
+      EZID_PASSWORD=$(grep config.password ${BOOTSTRAP_DIR}/files/ezid_secrets) && \
+        $RUN_AS_INSTALLUSER sed -i "/config.password/ c\  $EZID_PASSWORD" "$HYDRA_HEAD_DIR/config/initializers/ezid.rb"
+    else
+      echo 'Warning: No production ezid_secrets file supplied; using defaults!'
+    fi
     # Point to production CAS
     $RUN_AS_INSTALLUSER sed -i 's/config.omniauth \(.*\)cas-dev.middleware.vt.edu/config.omniauth \1auth.vt.edu/' "$HYDRA_HEAD_DIR/config/initializers/devise.rb"
     $RUN_AS_INSTALLUSER RAILS_ENV=${APP_ENV} bundle exec rake assets:precompile


### PR DESCRIPTION
This change allows a files/ezid_secrets file to be used during
bootstrap to provide EZ-ID DOI credentials to be provided in RAILS_ENV
"production" installs.

The file files/ezid_secrets is intended to contain replacement lines
for the following configuration variables that reside in the
application's config/initializers/ezid.rb file:
config.default_shoulder; config.user; and config.password.

The substitution searches for a line in files/ezid_secrets containing
one of the above-mentioned configuration variables, and, if present,
replaces the line containing that variable in
config/initializers/ezid.rb with the entire line found in
files/ezid_secrets.  Because of this, the replacement line in
files/ezid_secrets should be a complete, valid Ruby assignment of that
variable.

Below, is an example files/ezid_secrets file that would replace the
EZ-ID DOI credentials with the current development defaults (i.e., this
file would result in a no-op if applied):

=====8<=====
config.default_shoulder = "doi:10.5072/FK2"
config.user = "apitest"
config.password = "apitest"
=====>8=====

Note how each line is a valid Ruby assignment.

The files/ezid_secrets file is ignored if installing via Vagrant.
