### PR TITLE
Allow resque workers to exit gracefully.

### DIFF
--- a/bootstrap_server.sh
+++ b/bootstrap_server.sh
@@ -96,7 +96,7 @@ fi
 
 start() {
   cd "${HYDRA_HEAD_DIR}"
-  sudo -H -u $INSTALL_USER RAILS_ENV=${APP_ENV} bundle exec resque-pool --daemon --environment $APP_ENV --pidfile \$RESQUE_POOL_PIDFILE
+  sudo -H -u $INSTALL_USER RAILS_ENV=${APP_ENV} RUN_AT_EXIT_HOOKS=true TERM_CHILD=1 bundle exec resque-pool --daemon --environment $APP_ENV --pidfile \$RESQUE_POOL_PIDFILE
 }
 
 stop() {


### PR DESCRIPTION
Add RUN_AT_EXIT_HOOKS and TERM_CHILD to the command.

(from https://github.com/projecthydra/sufia/blob/6.x-stable/README.md#start-background-workers)
