### PR TITLE
Install FITS to /opt/fits

### DIFF
--- a/config_aws.sh
+++ b/config_aws.sh
@@ -11,7 +11,6 @@ APP_ENV="production"
 #APP_ENV="development"
 SOLR_CORE="$APP_ENV"
 INSTALL_DIR="/home/$INSTALL_USER"
-FITS_DIR="$INSTALL_DIR/fits" # Where FITS will be installed.
 HYDRA_HEAD_DIR="$INSTALL_DIR/$HYDRA_HEAD" # Where the Hydra head will be located.
 FEDORA4_DATA="$INSTALL_DIR/fedora-data"
 RUN_AS_INSTALLUSER="sudo -H -u $INSTALL_USER"

--- a/config_vagrant.sh
+++ b/config_vagrant.sh
@@ -6,7 +6,6 @@ APP_ENV="development" # What environment the app should run in. Should be 'devel
 #APP_ENV="production" # What environment the app should run in. Should be 'development' or 'production'
 SOLR_CORE="$APP_ENV"
 INSTALL_DIR="/home/$INSTALL_USER"
-FITS_DIR="$INSTALL_DIR/fits" # Where FITS will be installed.
 HYDRA_HEAD_DIR="$INSTALL_DIR/$HYDRA_HEAD" # Where the Hydra head will be located.
 FEDORA4_DATA="$INSTALL_DIR/fedora-data"
 RUN_AS_INSTALLUSER="sudo -H -u $INSTALL_USER"

--- a/install_sufia_application.sh
+++ b/install_sufia_application.sh
@@ -16,13 +16,15 @@ echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | /u
 apt-get install -y oracle-java8-installer
 update-java-alternatives -s java-8-oracle
 
-# Install FITS
+# Install FITS to /opt/fits
 apt-get install -y unzip
-$RUN_AS_INSTALLUSER mkdir -p $FITS_DIR
-cd "$FITS_DIR"
-$RUN_AS_INSTALLUSER wget --quiet "http://projects.iq.harvard.edu/files/fits/files/${FITS_PACKAGE}.zip"
-$RUN_AS_INSTALLUSER unzip -q ${FITS_DIR}/${FITS_PACKAGE}.zip
-chmod a+x ${FITS_DIR}/${FITS_PACKAGE}/fits.sh
+TMPFILE=$(mktemp -d)
+cd "$TMPFILE"
+wget --quiet "http://projects.iq.harvard.edu/files/fits/files/${FITS_PACKAGE}.zip"
+unzip -q "${FITS_PACKAGE}.zip" -d /opt
+ln -sf "/opt/${FITS_PACKAGE}" /opt/fits
+chmod a+x /opt/fits/fits.sh
+rm -rf "$TMPFILE"
 cd $INSTALL_DIR
 
 # Install ffmpeg
@@ -171,8 +173,6 @@ if [ "$APP_ENV" = "production" ]; then
 fi
 
 # Fix up configuration files
-# 1. FITS
-$RUN_AS_INSTALLUSER sed -i "s@config.fits_path = \".*\"@config.fits_path = \"$FITS_DIR/$FITS_PACKAGE/fits.sh\"@" config/initializers/sufia.rb
 # 2. Set Google Analytics ID, if supplied and we aren't installing via Vagrant
 if [ -f ${BOOTSTRAP_DIR}/files/google_analytics_id -a $PLATFORM != "vagrant" ]; then
   # Uncomment config.google_analytics_id setting


### PR DESCRIPTION
Currently, FITS is installed to $FITS_DIR, which is usually under the
$INSTALL_DIR.  The path to the "fits.sh" script is set in the Sufia
initialiser, config/initializers/sufia.rb.  This is done during install
by the install scripts, which change the value in the code to point to
the installed "fits.sh" script.

This change is so the latter fix-up is not necessary.  Instead of
installing to $FITS_DIR, we install FITS to a fixed location:
/opt/fits.  (We actually install to /opt/$FITS_PACKAGE and symlink
/opt/fits to there.  That would allow us in future potentially to have
several installed versions of FITS and point to the one we are using
via the symlink, as Solr does.)
