### PR TITLE
Fix resque-pool shutdown

### DIFF
--- a/bootstrap_server.sh
+++ b/bootstrap_server.sh
@@ -103,7 +103,10 @@ start() {
 }
 
 stop() {
-  [ -f \$RESQUE_POOL_PIDFILE ] && kill -QUIT \$(cat \$RESQUE_POOL_PIDFILE)
+  if [ -f \$RESQUE_POOL_PIDFILE ]; then
+    kill -QUIT \$(cat $RESQUE_POOL_PIDFILE)
+    while ps agx | grep resque | egrep -qv 'init.d|service|grep'; do sleep 1; done
+  fi
 }
 
 case "\$1" in


### PR DESCRIPTION
Resque-pool is shut down in an orderly fashion by sending a QUIT signal
to the resque-pool-master process.  This process instructs workers to
exit and it exits itself, removing its PID file.

Unfortunately, resque-pool-master can cause the resque-pool service
script to exit when workers are still in the process of shutting down.
This change is to have the service shutdown method wait until the
resque-pool processes are no longer running before it exits.

We assume resque-pool related processes include the word "resque" in
their process title.  We ignore the running init.d resque-pool script
itself, along with any service invocations (e.g., "service resque-pool
stop" commands).
