### PR TITLE
Comment sample secrets.yml file

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -103,11 +103,11 @@ fi
 if [ ! -f files/secrets.yml ]; then
   cat > files/secrets.yml <<END_OF_SECRETS
 default: &default
-  database:
+  database: &database
     name: datarepo
     username: $INSTALL_USER
     password: $DB_PASS
-  ezid:
+  ezid: &ezid
     default_shoulder: doi:10.5072/FK2
     user: apitest
     password: apitest
@@ -115,10 +115,10 @@ default: &default
     url: http://127.0.0.1:8080/fedora/rest
     user: fedoraAdmin
     password: fedoraAdmin
-  orcid:
+  orcid: &orcid
     app_id: 0000-0000-0000-0000
     app_secret: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
-  redis:
+  redis: &redis
     host: localhost
     port: 6379
   cas_endpoint_url: https://cas-dev.middleware.vt.edu

--- a/secrets.yml.sample
+++ b/secrets.yml.sample
@@ -1,42 +1,74 @@
+# Configuration secrets
+#
+# The config/secrets.yml file contains configuration settings for the
+# application.  They are available via the Rails.application.secrets mechanism.
+
+# Define defaults for all Rails environments
 default: &default
-  database:
-    name: datarepo
-    username: vagrant
-    password: changeme
-  ezid:
-    default_shoulder: doi:10.5072/FK2
-    user: apitest
-    password: apitest
+  # config/database.yml settings
+  database: &database
+    name: datarepo                                       # Database name
+    username: vagrant                                    # Database user
+    password: changeme                                   # Database password
+    # The host: and port: below are optional.  Do not use them unless you want
+    # to connect to a database over TCP/IP, e.g., one running on a different
+    # server.  If host: and port: are undefined, connection will be assumed to
+    # be local, e.g., via a Unix domain socket.  The port: setting will default
+    # to the correct one for the database adapter, and so should only be
+    # uncommented if the database is running on a non-standard port.
+  # host: example.com  # Hostname of database server
+  # port: 5432         # TCP/IP port of database server
+  ezid: &ezid
+    default_shoulder: doi:10.5072/FK2                    # Prefix for DOIs
+    user: apitest                                        # EZ-ID service username
+    password: apitest                                    # EZ-ID service password
   fedora: &fedora
-    url: http://127.0.0.1:8080/fedora/rest
-    user: fedoraAdmin
-    password: fedoraAdmin
-  orcid:
-    app_id: 0000-0000-0000-0000
-    app_secret: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
-  redis:
-    host: localhost
-    port: 6379
-  cas_endpoint_url: https://cas-dev.middleware.vt.edu
+    url: http://127.0.0.1:8080/fedora/rest               # URL of Fedora endpoint
+    user: fedoraAdmin                                    # Fedora username
+    password: fedoraAdmin                                # Fedora password
+  orcid: &orcid
+    app_id: 0000-0000-0000-0000                          # ORCID client ID
+    app_secret: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX     # ORCID client secret
+  redis: &redis
+    host: localhost # Hostname of Redis server
+    port: 6379      # TCP/IP port of Redis server
+  cas_endpoint_url: https://cas-dev.middleware.vt.edu    # URL of CAS service endpoint
+  # The google_analytics_id: below should only be defined if usage statistics
+  # are to be gathered.  Leave commented otherwise.
+# google_analytics_id: UA-99999999-1                     # Google Analytics tracking ID
+  # To get a working Rails application by using this file you'll need to
+  # uncomment and define secret_key_base: below.  It is typically set to a long,
+  # random string, such as the output of "openssl rand -hex 64" (or the output
+  # of the "rake secret" task).
+# secret_key_base:                                       # Don't forget to define this!
+
+# These are the settings applicable for RAILS_ENV=development.  They inherit
+# settings from the above "default".
 development:
   <<: *default
   fedora:
     <<: *fedora
     base_path: /dev
-  blacklight_url: http://127.0.0.1:8983/solr/development
-  solr_url: http://localhost:8983/solr/development
+  blacklight_url: http://127.0.0.1:8983/solr/development # Blacklight endpoint URL
+  solr_url: http://localhost:8983/solr/development       # Solr endpoint URL
+
+# These are the settings applicable for RAILS_ENV=test.  They inherit settings
+# from the above "default".
 test:
   <<: *default
   fedora:
     <<: *fedora
     base_path: /test
-  blacklight_url: http://127.0.0.1:8983/solr/test
-  solr_url: http://localhost:8983/solr/test
+  blacklight_url: http://127.0.0.1:8983/solr/test        # Blacklight endpoint URL
+  solr_url: http://localhost:8983/solr/test              # Solr endpoint URL
   secret_key_base: abad1dea
+
+# These are the settings applicable for RAILS_ENV=production. They inherit
+# settings from the above "default".
 production:
   <<: *default
   fedora:
     <<: *fedora
     base_path: /prod
-  blacklight_url: http://127.0.0.1:8983/solr/production
-  solr_url: http://localhost:8983/solr/production
+  blacklight_url: http://127.0.0.1:8983/solr/production  # Blacklight endpoint URL
+  solr_url: http://localhost:8983/solr/production        # Solr endpoint URL


### PR DESCRIPTION
Added comments to the secrets.yml.sample file that is intended to be
edited and dropped into files/ during bootstrap.  The comments give
some guidance as to the meanings of the various YAML keys.  Keys that
are not normally present are included but commented out.

I also added some extra anchors to the default section so that
individual items may be overridden, like that done for fedora:.  These
anchors are also included in the vanilla secrets.yml file generated if
no files/secrets.yml file is present when running bootstrap.sh.
