### PR TITLE
Fix resque-pool shutdown

### DIFF
--- a/bootstrap_server.sh
+++ b/bootstrap_server.sh
@@ -105,7 +105,7 @@ start() {
 stop() {
   if [ -f \$RESQUE_POOL_PIDFILE ]; then
     kill -QUIT \$(cat \$RESQUE_POOL_PIDFILE)
-    while ps agx | grep resque | egrep -qv 'init.d|service|grep'; do sleep 1; done
+    while ps agx | grep resque | egrep -qv 'rc[0-9]\.d|init\.d|service|grep'; do sleep 1; done
   fi
 }
 


### PR DESCRIPTION
When shutting down Resque-pool, the service script checks there are no
more running "resque" processes other than those associated with
running the /etc/init.d/resque-pool script itself.  Previously, the
latter check omitted the case in which the script was being run via a
system shutdown (i.e., runlevel script).  This commit fixes that issue.
