### PR TITLE
Configure Nginx maximum upload size

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -26,6 +26,8 @@ NGINX_SITE="$NGINX_CONF_DIR/sites-available/$HYDRA_HEAD.site"
 NGINX_CLIENT_RATE="75r/s"
 NGINX_CLIENT_BURST="500"
 NGINX_BURST_OPTION="nodelay"
+# Cap the size of uploads
+NGINX_MAX_UPLOAD_SIZE="200M"
 # Where the TLS certificate resides
 SSL_CERT_DIR="/etc/ssl/local/certs"
 SSL_CERT="$SSL_CERT_DIR/$HYDRA_HEAD-crt.pem"

--- a/install_sufia_application.sh
+++ b/install_sufia_application.sh
@@ -79,7 +79,7 @@ limit_req_zone \$binary_remote_addr zone=clients:1m rate=${NGINX_CLIENT_RATE};
 server {
     listen 80;
     listen 443 ssl;
-    client_max_body_size 200M;
+    client_max_body_size ${NGINX_MAX_UPLOAD_SIZE};
     passenger_min_instances ${PASSENGER_INSTANCES};
     limit_req zone=clients burst=${NGINX_CLIENT_BURST} ${NGINX_BURST_OPTION};
     root ${HYDRA_HEAD_DIR}/public;


### PR DESCRIPTION
Previously, we hardcoded a value for the maximum size of an upload.
This change allows the value to be set in a config*.sh configuration
file instead via the NGINX_MAX_UPLOAD_SIZE setting.
