### PR TITLE
Switch to VT Login SSO endpoints

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -121,7 +121,7 @@ default: &default
   redis: &redis
     host: localhost
     port: 6379
-  cas_endpoint_url: https://cas-dev.middleware.vt.edu
+  cas_endpoint_url: https://login-dev.middleware.vt.edu/profile/cas
   secret_key_base: $(openssl rand -hex 64)
 development:
   <<: *default

--- a/secrets.yml.sample
+++ b/secrets.yml.sample
@@ -32,7 +32,10 @@ default: &default
   redis: &redis
     host: localhost # Hostname of Redis server
     port: 6379      # TCP/IP port of Redis server
-  cas_endpoint_url: https://cas-dev.middleware.vt.edu    # URL of CAS service endpoint
+  # URL of CAS service endpoint.  Use one of the following endpoints at Virginia Tech:
+  # Development: https://login-dev.middleware.vt.edu/profile/cas
+  # Production: https://login.vt.edu/profile/cas
+  cas_endpoint_url: https://login-dev.middleware.vt.edu/profile/cas
   # The google_analytics_id: below should only be defined if usage statistics
   # are to be gathered.  Leave commented otherwise.
 # google_analytics_id: UA-99999999-1                     # Google Analytics tracking ID


### PR DESCRIPTION
Use the new VT Login SSO service instead of the old CAS service, which
will be retiring in the near future.
