### PR TITLE
Make Solr logs less "chatty" by default.

### DIFF
--- a/install_solr.sh
+++ b/install_solr.sh
@@ -49,5 +49,5 @@ $RUN_AS_SOLR_USER ln -s $SOLR_INSTALL/solr/dist
 $RUN_AS_SOLR_USER mkdir lib
 $RUN_AS_SOLR_USER ln -s $SOLR_INSTALL/solr/contrib lib/contrib
 # Adjust logging settings
-$RUN_AS_SOLR_USER sed -i 's/^log4j.rootLogger=.*$/log4j.rootLogger=INFO, file/' /var/solr/log4j.properties
+$RUN_AS_SOLR_USER sed -i 's/^log4j.rootLogger=.*$/log4j.rootLogger=WARN, file/' /var/solr/log4j.properties
 $RUN_AS_SOLR_USER sed -i "s/file.MaxFileSize=.*$/file.MaxFileSize=${SOLR_LOGSIZE}/" /var/solr/log4j.properties


### PR DESCRIPTION
Change the default log level from INFO to WARN so that only warnings
and errors will be logged.
