### PR TITLE
Point Solr distribution URL to Apache archives, not releases

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -38,7 +38,7 @@ SSL_KEY="$SSL_KEY_DIR/$HYDRA_HEAD-key.pem"
 SOLR_USER="solr"
 # Which Solr version we will install
 SOLR_VERSION="5.2.1"
-SOLR_MIRROR="http://www.apache.org/dist/lucene/solr/$SOLR_VERSION/"
+SOLR_MIRROR="http://archive.apache.org/dist/lucene/solr/$SOLR_VERSION/"
 SOLR_DIST="solr-$SOLR_VERSION"
 # The directory under which we will install Solr.
 SOLR_INSTALL="/opt"


### PR DESCRIPTION
The current SOLR_MIRROR URL stub used to fetch the Solr distribution
(http://www.apache.org/dist/lucene/solr) is a poor choice because it
now only tracks the latest supported releases. A better choice would be
the Apache archive releases link
(http://archive.apache.org/dist/lucene/solr), which contains past
releases, too. This will mean the download link will not break
unexpectedly, as with the current one now.
