### PR TITLE
Adds a synced folder for virtualbox

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,10 +2,11 @@
 
 Vagrant.configure(2) do |config|
   config.vm.box = 'ubuntu/trusty64'
-  config.vm.provider 'virtualbox' do |vb|
+  config.vm.provider 'virtualbox' do |vb, override|
     vb.name = 'data-repo-dev'
     vb.cpus = 2
     vb.memory = 4096
+    override.vm.synced_folder "../data-repo", "/home/vagrant/data-repo", create: true, disabled: false
   end
   # Forward Solr port in VM to local machine
   config.vm.network :forwarded_port, host: 8983, guest: 8983

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -81,6 +81,22 @@ fi
 [ -f "${SCRIPTS_DIR}/config.sh" ] && . "${SCRIPTS_DIR}/config.sh"
 [ -f "${SCRIPTS_DIR}/config_${SERVER_ENV}.sh" ] && . "${SCRIPTS_DIR}/config_${SERVER_ENV}.sh"
 
+# Check for sync folder, and make sure it's empty
+if [[ -d "../${HYDRA_HEAD}/" && $(ls -A "../${HYDRA_HEAD}/") ]]; then
+    echo "The local directory '../${HYDRA_HEAD}/' exists, and is not empty."
+    echo "If you continue, this directory will be deleted. You may lose your work."
+    # Only accept an answer for five seconds.
+    read -t 5 -p 'Do you want to continue? [y|N] ' REPLY
+    # Only proceed if something was read, and it was some form of yes.
+    if [[ $? -eq 0 && $REPLY =~ ^[Yy]([Ee][Ss])?$ ]]; then
+        echo "Deleting ../${HYDRA_HEAD}"
+        rm -rf "../${HYDRA_HEAD}"
+    else
+        echo "Please remove ../${HYDRA_HEAD} and try again."
+        exit 1
+    fi
+fi
+
 # Check that the deployment key exists in files/ if specified
 if [ -n "$HYDRA_HEAD_GIT_REPO_DEPLOY_KEY" ]; then
   if [ ! -f "files/$HYDRA_HEAD_GIT_REPO_DEPLOY_KEY" ]; then

--- a/install_sufia_application.sh
+++ b/install_sufia_application.sh
@@ -70,6 +70,7 @@ apt-get install -y nginx-extras passenger
 # Uncomment passenger_root and passenger_ruby lines from config file
 TMPFILE=`/bin/mktemp`
 cat $NGINX_CONF_FILE | \
+  sed "s/sendfile on;/sendfile off;/" | \
   sed "s/worker_processes .\+;/worker_processes auto;/" | \
   sed "s@# include /etc/nginx/passenger.conf;@include /etc/nginx/passenger.conf;@" > $TMPFILE
 sed "1ienv PATH;" < $TMPFILE > $NGINX_CONF_FILE


### PR DESCRIPTION
- Syncs ../data-repo/ on the host to /home/vagrant/data-repo on the VM.
- ../data-repo will be emptied when the VM is provisioned.
- The synced folder is only created for the virtualbox provider.
- The folder can be disabled by changing the disabled setting to true in the Vagrantfile.
- Sendfile is disabled for nginx, to prevent file corruption in the synced folder.
- Using this feature requires rebuilding the VM.
