### PR TITLE
Support provisioning to AWS and OpenStack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,20 @@
-# Install Scripts for Hydra Applications
+Install Scripts for Hydra/Rails Applications
+============================================
 
-These files are used to install the a Virginia Tech Hydra Head on a target server. They can be used to install the application to a VM under VirtualBox. Installation is done via [Vagrant](https://www.vagrantup.com/). Alternatively, Ansible may be used directly to set up the application on a suitable target system.
+These files are used to install a Virginia Tech Hydra Head (or other supported application) on a target server. They can be used to install the application either to a VM under VirtualBox; to a server running under Amazon Web Services (AWS); or to a server running under OpenStack in the Chameleon Cloud. Installation is done via [Vagrant](https://www.vagrantup.com/). Alternatively, Ansible may be used directly to set up the application on a suitable target system.
 
-When installing the  application, the `vagrant up` command is used to set up the server and deploy the application on a local VM.
+The `vagrant up` command is used to set up the server and deploy the application on the chosen platform. To deploy to AWS, select the `aws` Vagrant provider: `vagrant up --provider aws`.  To deploy to OpenStack in the Chameleon Cloud, select the `openstack` provider: `vagrant up --provider openstack`. If no provider is specified, it defaults to VirtualBox, which will set up a local VM.
 
-## Installation
+Installation
+------------
 
 These scripts are intended to be run on a Unix-like system. They are tested to work on Mac OSX.
 
-To use these scripts, [Vagrant](https://www.vagrantup.com/) must already have been installed on the local system with the [VirtualBox](http://www.virtualbox.org) provider.
+To use these scripts, [Vagrant](https://www.vagrantup.com/) must already have been installed on the local system with the [VirtualBox](http://www.virtualbox.org) provider working. For provisioning to AWS, the `aws` provider must also be installed. This can be done by executing the following command, which will install the `aws` Vagrant provider plugin: `vagrant plugin install vagrant-aws`. To provision to the OpenStack Chameleon Cloud, the `openstack` provider needs to be installed. It can be installed via the following command: `vagrant plugin install vagrant-openstack-provider`.
 
-You will need version 2.0+ of [Vagrant](https://vagrantup.com) and a version of  [Ansible](https://ansible.com) at least 2.1+ installed on the local system.
+You will need version 1.6+ of [Vagrant](https://vagrantup.com) installed on the local system.
+
+If you choose to use the `ansible` Vagrant provisioner (see below), a version of  [Ansible](https://ansible.com) at least 2.1+ must also be installed on the local system.
 
 Ansible is easily installed via [Homebrew](http://brew.sh) on Mac OSX via the following command:
 
@@ -18,32 +22,97 @@ Ansible is easily installed via [Homebrew](http://brew.sh) on Mac OSX via the fo
 brew install ansible
 ```
 
-Finally, these install scripts must be installed on the local machine. Cloning this repository is encouraged.
+Finally, these install scripts must be installed on the local machine. This is most easily done by cloning the repository containing them.
 
-## Configuration
+Configuration
+-------------
 
-
-A deployment settings file needs to be created in the `ansible/` directory. This file is called `site_secrets.yml` and is easily created by copying the example file `example_site_secrets.yml`:
+For all environments, a deployment settings file needs to be created in the `ansible/` directory. This file is called `site_secrets.yml` and is easily created by copying the example file `example_site_secrets.yml`:
 
 ```
 cp example_site_secrets.yml site_secrets.yml
 ```
 
-The Ansible playbook will be expecting a repository-ignored `site_secrets.yml` YAML file. Read the variable contents of the file and adjust accordingly to match your local environment. To install the Hydra Head in the Rails production environment, the `project_secret_key_base` must be set. Acceptable values for this setting are the output of `openssl rand -hex 64`, or `bundle exec rake secret`.
+The Ansible playbook will be expecting a repository-ignored `site_secrets.yml` YAML file. Read the variable contents of the file and adjust accordingly to match your local environment.
 
 #### TLS certificate and key
 
-A TLS certificate and key file may be placed in the `ansible/roles/sufia/files/` directory for use in the system being set up. The certificate should be named `cert.pem` and the key named `key.pem`
+A TLS certificate and key file may be placed in the `local_files/` directory for use in the system being set up. The certificate should be named `local_files/cert.pem` and the key named `local_files/key.pem`.
 
 If either of the aforementioned files is not present then a self-signed TLS certificate and key pair will be generated and used instead.
 
-## Usage
+#### Authorized keys for SFTP
 
-To install a hydra application from scratch on a server using the current local configuration file settings, do the following:
+The chroot SFTP server limits the upload user to public key based authentication only. As such, the upload user's `authorized_keys` file is used to determine which people may log in as the upload user via SFTP.
+
+SSH public key files should be placed in `local_files/authorized_keys/` prior to setup. These public keys will be added to the upload user's `~/.ssh/authorized_keys` file. (Note, files in `local_files/authorized_keys/` should contain only public keys.)
+
+If no public keys are supplied then the upload user's `~/.ssh/authorized_keys` file will have to be set up manually afterwards to enable the upload user to log in via SFTP.
+
+#### Choosing a Vagrant Ansible provisioner
+
+Vagrant supports two Ansible provisioners: `ansible` and `ansible_local`. These basically achieve the same end result but differ in how that is achieved.
+
+With the `ansible` provisioner, a version of Ansible that is installed on the local system is used to provision the system that Vagrant creates. This Ansible software must be installed prior to invoking `vagrant up`.
+
+The Vagrant `ansible_local` provisioner, on the other hand, installs Ansible on the system that Vagrant creates and then uses this to provision the machine. No Ansible software need be installed locally when using the `ansible_local` Vagrant provisioner.
+
+The choice of provisioner may be made by setting the environment variable `ANSIBLE_PROVISIONER` prior to running `vagrant up`. This should be set to either `ansible` or `ansible_local`. If that environment is unset, or is set to something other than those two choices, then it is set to `ansible_local`.
+
+#### Choosing a target application to install
+
+Normally, `vagrant up` will be able to determine the type of application you want to provision based upon settings in the `site_secrets.yml` file. You can override this choice by setting the `APP_TYPE` environment variable to the chosen application prior to `vagrant up`.  Valid settings for `APP_TYPE` are either `sufia` or `geoblacklight`.
+
+### AWS
+
+When using the `aws` provider to `vagrant up` it is necessary to define several environment variables in order to authenticate to AWS and supply a keypair with which Vagrant can log in to the new AWS EC2 instance being deployed.  These environment variables are as follows:
+
+- `KEYPAIR_NAME`: the name of the AWS keypair that will be used to log in to the instance. This keypair should already exist within your AWS account and its private key file should reside on the local system.
+- `KEYPAIR_FILE`: the pathname of the private key on the local system corresponding to the aforementioned keypair.
+- `AWS_ACCESS_KEY`: the AWS IAM access key to the account under which the EC2 instance will be created.
+- `AWS_SECRET_KEY`: the AWS IAM secret key to the account under which the EC2 instance will be created.
+- `AWS_SECURITY_GROUPS`: a space-separated list of existing AWS security groups to apply to this instance. (If `AWS_SECURITY_GROUPS` is not set then a default security group is used.)
+
+WARNING: Many of the other AWS EC2 instance settings (e.g., instance type) are set directly in the `Vagrantfile` and make sense only for VTUL users. Please check these are appropriate before bringing up the instance with Vagrant and edit where necessary beforehand.
+
+### OpenStack
+
+When deploying to the OpenStack Chameleon Cloud, several environment variables must be defined in order to authenticate to OpenStack and define a keypair to be used to log in to the new Chameleon Cloud instance being deployed.  The following environment variables must be defined:
+
+- `KEYPAIR_NAME`: the name of the OpenStack keypair that will be used to log in to the instance. This keypair should already exist within your OpenStack account and its private key file should reside on the local system.
+- `KEYPAIR_FILE`: the pathname of the private key on the local system corresponding to the aforementioned keypair.
+- `OS_FLOATING_IP`: the floating IP address (as a "dotted quad", i.e., x.x.x.x) to be assigned to this instance. This floating IP must already be available to the OpenStack project under which the instance is being deployed.
+- `OS_SECURITY_GROUPS`: a space-separated list of existing OpenStack security groups to apply to this instance. (If `OS_SECURITY_GROUPS` is not set then a default security group is used.)
+- `OS_USERNAME`: your OpenStack user name
+- `OS_PASSWORD`: your OpenStack login password
+- `OS_AUTH_URL`: the URL of the OpenStack endpoint
+- `OS_TENANT_NAME`: the ID of your OpenStack Chameleon Cloud project (tenant)
+- `OS_REGION_NAME`: the OpenStack region in which you wish to deploy the instance
+
+The `OS_USERNAME`; `OS_PASSWORD`; `OS_AUTH_URL`; `OS_TENANT_NAME`; and `OS_REGION_NAME` settings are most easily set via an OpenStack RC file downloaded via the OpenStack dashboard. To do this, log in to the dashboard and select the "Compute" -> "Access & Security" page. On that page, select the "API Access" tab. Click the "Download OpenStack RC File" to download the RC script to your local system. This is a bash script that sets the aforementioned environment variables when run. The script also prompts the user to enter his or her OpenStack password. The `OS_PASSWORD` environment variable is set to the value entered. You should run this script to define those environment variables prior to deploying via Vagrant, e.g., by executing `. /path/to/OpenStack_RC_File.sh`.
+
+Usage
+-----
+
+To install the chosen application from scratch on a server using the current local configuration file settings, do the following:
 
 ```
 cd /path/to/install/scripts
 vagrant up
+```
+
+This will install to a local VM. To install to AWS do the following:
+
+```
+cd /path/to/install/scripts
+vagrant up --provider aws
+```
+
+If you wish to install to OpenStack then do the following:
+
+```
+cd /path/to/install/scripts
+vagrant up --provider openstack
 ```
 
 If using Ansible directly, you will need the IP address of the server you plan to provision. Execute the following command:
@@ -55,13 +124,61 @@ ansible-playbook --limit [ip address] site.yml -b
 
 ### Local VM
 
-In the case of the plain `vagrant up` option, a VM will be brought up and configured in the current directory. The hydra application is accessible on the local machine from a Web browser at `https://localhost:4443`.
+In the case of the plain `vagrant up` option, a VM will be brought up and configured in the current directory. The application is accessible on the local machine from a Web browser.
 
-You can use `vagrant ssh` to log in to this VM when it is up. When logged out of the VM, `vagrant halt` can be used to shut down the VM. The command `vagrant destroy` will destroy it entirely, requiring another `vagrant up` to recreate it. To reapply the ansible roles, use `vagrant provision`.
+You can use `vagrant ssh` to log in to this VM when it is up. When logged out of the VM, `vagrant halt` can be used to shut down the VM. The command `vagrant destroy` will destroy it entirely, requiring another `vagrant up` to recreate it.
+
+Several ports in the running VM are made accessible on the local machine.
+Accessing the local port in a Web browser will actually result in the forwarded
+port being accessed on the VM. These ports are as follows:
+
+Local | VM   | Description
+----- | ---- | -----------
+8983  | 8983 | Solr services
+8888  | 8080 | Tomcat (if applicable)
+8080  | 80   | Application (HTTP)
+4443  | 443  | Application (HTTPS)
+
+To access the Solr admin page in the VM from the local machine you would access
+this URL: `http://localhost:8983/solr`.  (Note that only the "Local" ports in the above table are directly accessible from the local machine.)
+
+### AWS
+
+For the `vagrant up --provider aws` option, a server running the application will be provisioned in AWS. After a while, it should be possible to log in to this machine via SSH:
+
+```
+vagrant ssh
+```
+
+The installation and setup of the application and associated software could take quite a while. Its progress will be logged to the screen during the execution of `vagrant up --provider aws`.
+
+When installation is complete and services are running, you can access the application via this URL: `https://$SERVER_HOSTNAME`, where `$SERVER_HOSTNAME` is the hostname of the AWS instance just deployed.  This can be determined by running the following command in the installation scripts directory:
+
+```
+vagrant ssh-config | grep HostName | awk '{print $2}'
+```
+
+Vagrant commands such as `halt` and `destroy` behave analogously on the AWS instance as they do for local Vagrant VMs.
+
+### OpenStack
+
+Installation to OpenStack is similar to that of AWS above. After provisioning with `vagrant up --provider openstack` it should be possible to log in to the newly-deployed machine via SSH:
+
+```
+vagrant ssh
+```
+
+As with the `aws` provider, the application can be accessed via the URL `https://$SERVER_HOSTNAME`, where `$SERVER_HOSTNAME` is the hostname of the OpenStack instance just deployed. You can determine the hostname by using the following command:
+
+```
+vagrant ssh-config | grep HostName | awk '{print $2}'
+```
+
+As with the `aws` provider, Vagrant commands such as `halt` and `destroy` behave analogously on the OpenStack instance as they do for local Vagrant VMs.
 
 ### Ansible
 
-When using Ansible to provision directly, the playbook will be executed on the server whose IP address is given as `IP`. When the playbook finishes with no failures, the VT hydra server is accessible at this URL:
+When using Ansible to provision directly, the playbook will be executed on the server whose IP address is given as `IP`. When the playbook finishes with no failures, the server is accessible at this URL:
 
 ```
 http://[IP]

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,3 +1,19 @@
+#-*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# To install under OpenStack the Vagrant openstack provider needs to be installed.
+# You can install this plugin by running the following command:
+#
+#   vagrant plugin install vagrant-openstack-provider
+#
+# To install under AWS you need to have the vagrant-aws provider plugin installed.
+# You can install this using the following command:
+#
+#   vagrant plugin install vagrant-aws
+#
+# If no "--provider" is specified during "vagrant up" then the default
+# (VirtualBox) provider will be used.
+
 VAGRANTFILE_API_VERSION = "2"
 
 def site_file
@@ -30,29 +46,84 @@ def vagrant_ansible_provisioner
   end
 end
 
+def security_groups( env_var )
+  s = ENV[ env_var ]
+  if s.nil?
+    # Return some default
+    case env_var
+      when "OS_SECURITY_GROUPS"  then ["web", "vt-ssh"]
+      when "AWS_SECURITY_GROUPS" then ["default_vpc_web_vt_ssh"]
+      else                            []
+    end
+  else
+    s.split
+  end
+end
+
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  config.vm.provider :virtualbox do |vb|
-    vb.memory = 4096
-    vb.cpus = 2
-  end
 
-  # Hydra server
-  config.vm.define "hydravm" do |hydravm|
-    hydravm.vm.box = "ubuntu/trusty64"
-
-    # Forward Solr port in VM to local machine
-    config.vm.network :forwarded_port, host: 8983, guest: 8983
-    # Forward Tomcat/Fedora port in VM to port 8888 on local machine
-    config.vm.network :forwarded_port, host: 8888, guest: 8080
-    # Forward HTTP port in VM to port 8080 on local machine
-    config.vm.network :forwarded_port, host: 8080, guest: 80
-    # Forward HTTPS port in VM to port 4443 on local machine
-    config.vm.network :forwarded_port, host: 4443, guest: 443
-  end
-
-  # Ansible provisioning
+  # Ansible provisioner default settings
   config.vm.provision vagrant_ansible_provisioner() do |ansible|
     ansible.playbook = "ansible/#{site_file()}_site.yml"
     ansible.verbose = ""
+  end
+
+  # Application server
+  config.vm.define :hydravm do |hydravm|
+    hydravm.vm.hostname = "hydravm"
+
+    hydravm.vm.provider :virtualbox do |vb, override|
+      override.vm.box = "ubuntu/trusty64"
+      vb.memory = 4096
+      vb.cpus = 2
+      # Forward Solr port in VM to local machine
+      override.vm.network :forwarded_port, host: 8983, guest: 8983
+      # Forward Tomcat/Fedora port in VM to port 8888 on local machine
+      override.vm.network :forwarded_port, host: 8888, guest: 8080
+      # Forward HTTP port in VM to port 8080 on local machine
+      override.vm.network :forwarded_port, host: 8080, guest: 80
+      # Forward HTTPS port in VM to port 4443 on local machine
+      override.vm.network :forwarded_port, host: 4443, guest: 443
+    end
+
+    hydravm.vm.provider :openstack do |os, override|
+      keypair = "#{ENV['KEYPAIR_NAME']}"
+      keypair_filename = "#{ENV['KEYPAIR_FILE']}"
+      # OpenStack authentication information
+      os.openstack_auth_url = "#{ENV['OS_AUTH_URL']}/tokens"
+      os.username     = "#{ENV['OS_USERNAME']}"
+      os.password     = "#{ENV['OS_PASSWORD']}"
+      os.tenant_name  = "#{ENV['OS_TENANT_NAME']}"
+      os.region       = "#{ENV['OS_REGION_NAME']}"
+      override.ssh.username = "cc"
+      os.keypair_name = keypair # as stored in Nova
+      override.ssh.private_key_path = "#{keypair_filename}"
+      # OpenStack image information
+      os.flavor       = "m1.medium"
+      os.image        = "Ubuntu-Server-14.04-LTS"
+      os.security_groups = security_groups('OS_SECURITY_GROUPS')
+      os.floating_ip  = "#{ENV['OS_FLOATING_IP']}"
+      os.server_name  = site_file()
+    end
+
+    hydravm.vm.provider :aws do |aws, override|
+      keypair = "#{ENV['KEYPAIR_NAME']}"
+      keypair_filename = "#{ENV['KEYPAIR_FILE']}"
+      override.vm.box = "aws_dummy"
+      override.vm.box_url = "https://github.com/mitchellh/vagrant-aws/raw/master/dummy.box"
+      override.vm.box_check_update = false
+      aws.access_key_id = ENV['AWS_ACCESS_KEY']
+      aws.secret_access_key = ENV['AWS_SECRET_KEY']
+      aws.keypair_name = keypair
+      aws.ami = "ami-df0607b5" # Ubuntu Trusty LTS
+      aws.region = "us-east-1"
+      aws.instance_type = "t2.small"
+      aws.security_groups = security_groups('AWS_SECURITY_GROUPS')
+      override.ssh.username = "ubuntu"
+      override.ssh.private_key_path = "#{keypair_filename}"
+      aws.tags = {
+        'Name' => site_file()
+      }
+    end
   end
 end

--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -8,4 +8,4 @@
     - acl
     - build-essential
     - apt-transport-https
-    - software-properties-common
+    - python-apt


### PR DESCRIPTION
This supports using Vagrant to provision to AWS and OpenStack servers
in addition to local VMs.
