### PR TITLE
Set GeoBlacklight application secrets from Ansible site_secrets.yml

### DIFF
--- a/ansible/roles/geoblacklight/tasks/geoblacklight_setup.yml
+++ b/ansible/roles/geoblacklight/tasks/geoblacklight_setup.yml
@@ -16,19 +16,13 @@
     force: yes
   become_user: "{{ project_user }}"
 
-- name: check for secrets file
-  stat:
-    path: "{{ project_app_root }}/config/secrets.yml"
-  register: secret
-
-- name: openssl key
-  command: /usr/bin/openssl rand -hex 64
-  register: ssl_result
-
 - name: copy the secrets file
   template:
     src: secrets.yml.j2
     dest: "{{ project_app_root }}/config/secrets.yml"
+    owner: "{{ project_user }}"
+    group: "{{ project_group }}"
+    mode: "0440"
 
 - name: install production gems
   bundler:

--- a/ansible/roles/geoblacklight/templates/secrets.yml.j2
+++ b/ansible/roles/geoblacklight/templates/secrets.yml.j2
@@ -1,2 +1,28 @@
-{{ project_app_env }}:
-  secret_key_base: {{ ssl_result.stdout }}
+# Configuration secrets
+#
+# The config/secrets.yml file contains configuration settings for the
+# application.  They are available via the Rails.application.secrets mechanism.
+
+# Define defaults for all Rails environments
+default: &default
+  blacklight_url: {{ project_solr_url }}/{{ project_solr_core }}
+  ingest_dir: {{ sftp_upload_root }}
+  # secret_key_base is typically set to a long, random string, such as the output
+  # of "openssl rand -hex 64" (or the output of the "rake secret" task).
+  secret_key_base: abad1dea
+
+# These are the settings applicable for RAILS_ENV=development.  They inherit
+# settings from the above "default".
+development:
+  <<: *default
+
+# These are the settings applicable for RAILS_ENV=test.  They inherit settings
+# from the above "default".
+test:
+  <<: *default
+
+# These are the settings applicable for RAILS_ENV=production. They inherit
+# settings from the above "default".
+production:
+  <<: *default
+  secret_key_base: {{ project_secret_key_base }}


### PR DESCRIPTION
This allows settings in config/secrets.yml to be set based up project
settings in the Ansible site_secrets.yml file.  Previously, only
"secret_key_base" was set (randomly).  This commit adds more
configurable settings to config/secrets.yml and sets them with actual
site_secrets.yml configuration data.
