### PR TITLE
Increase default size of uploads

### DIFF
--- a/ansible/roles/sufia/defaults/main.yml
+++ b/ansible/roles/sufia/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 passenger_instances: 2
-nginx_max_upload_size: 5200
+nginx_max_upload_size: "200m"
 tls_cert_subject: "/C=US/ST=Virginia/O=Virginia Tech/localityName=Blacksburg/commonName={{ ansible_fqdn }}/organizationalUnitName=University Libraries"
 tls_cert_dir: /etc/ssl/local/certs
 tls_cert_file: cert.pem


### PR DESCRIPTION
The current default size (5200 bytes) for uploads in the "sufia" role
is far too small to upload anything of practical size.  Here, we
increase it to a more useful 200 MB.
