### PR TITLE
Install unzip

### DIFF
--- a/ansible/roles/sufia/tasks/main.yml
+++ b/ansible/roles/sufia/tasks/main.yml
@@ -6,6 +6,7 @@
     update_cache: yes
   with_items:
     - git
+    - unzip
     - imagemagick
     - libreoffice
     - sqlite3


### PR DESCRIPTION
The "data-repo" and "iawa" Sufia projects both require "unzip" to be
installed for post-installation rake tasks to work.  We install "unzip"
as part of the generic Sufia dependencies list.

Note: it might appear a more natural place to install such a dependency
is in the {iawa,data-repo}.yml task of the sufia role that handles
per-project post-installation tasks.  However, those are executed as
part of a large block that has "become: yes" and "become_user: '{{
project_user }}'", which prevents installing packages via apt.  Thus,
we install unzip as part of the general Sufia dependencies instead.

(When unzip is no longer a common requirement for all our Sufia
projects we can change this code.)
