### PR TITLE
Add Ansible role to install FITS

### DIFF
--- a/ansible/roles/fits/README.md
+++ b/ansible/roles/fits/README.md
@@ -1,0 +1,17 @@
+Fits
+====
+
+Installs FITS under /opt and symlinks the version installed to /opt/fits
+
+Requirements
+------------
+
+This requires our Common role.
+
+Role Variables
+--------------
+
+Role variables are listed below:
+
+- `fits_version`: The version number of FITS to be installed, e.g., 0.6.2.
+- `fits_download_url`: Base download URL from which FITS distribution .zip files may be downloaded.

--- a/ansible/roles/fits/defaults/main.yml
+++ b/ansible/roles/fits/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+fits_version: "{{ '0.8.5' if project_name == 'iawa' else '0.6.2' }}"
+fits_download_url: http://projects.iq.harvard.edu/files/fits/files

--- a/ansible/roles/fits/meta/main.yml
+++ b/ansible/roles/fits/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - { role: common }

--- a/ansible/roles/fits/tasks/main.yml
+++ b/ansible/roles/fits/tasks/main.yml
@@ -1,0 +1,40 @@
+---
+- name: install fits installation dependencies
+  apt:
+    name: "{{ item }}"
+    state: present
+    update_cache: yes
+  with_items:
+    - unzip
+
+- name: download fits distribution to /tmp
+  get_url:
+    url: "{{ fits_download_url }}/fits-{{ fits_version }}.zip"
+    dest: /tmp/fits-{{ fits_version }}.zip
+    owner: root
+    group: root
+    mode: 0444
+    timeout: 100
+
+- name: unarchive fits distribution
+  unarchive:
+    src: /tmp/fits-{{ fits_version }}.zip
+    dest: /opt
+    remote_src: yes
+    creates: /opt/fits-{{ fits_version }}/fits.sh
+
+- name: ensure fits directory is accessible
+  file:
+    path: /opt/fits-{{ fits_version }}
+    mode: a+x
+
+- name: link desired version of fits to {{fits_root}}/fits
+  file:
+    src: /opt/fits-{{ fits_version }}
+    dest: /opt/fits
+    state: link
+
+- name: ensure fits.sh is executable
+  file:
+    path: /opt/fits-{{ fits_version }}/fits.sh
+    mode: a+x

--- a/ansible/roles/sufia/meta/main.yml
+++ b/ansible/roles/sufia/meta/main.yml
@@ -2,6 +2,7 @@
 dependencies:
   - { role: project_user }
   - { role: common }
+  - { role: fits }
   - { role: passenger }
   - { role: clamav }
   - { role: ffmpeg }


### PR DESCRIPTION
This adds a "fits" role to install FITS for Sufia applications and adds
it as a dependency of the "sufia" role.  FITS is installed to /opt and
the version installed is symlinked to /opt/fits (as in the previous
BASH script InstallScripts).

Version 0.8.5 of FITS is installed for IAWA (i.e., Sufia 7); version
0.6.2 otherwise.  This can be overridden by setting "fits_version" to
the desired version in site_secrets.yml.
