### PR TITLE
Fix data_ingest cron job

### DIFF
--- a/ansible/roles/geoblacklight/tasks/cron.yml
+++ b/ansible/roles/geoblacklight/tasks/cron.yml
@@ -4,6 +4,9 @@
     user: "{{ project_user }}"
     hour: 0
     cron_file: geoblacklight_ingest
-    job: cd "{{ project_app_root }}" && RAILS_ENV={{ project_app_env }} bundle exec rake vtul:geoblacklight:data_ingest
+    job: >
+      cd "{{ project_app_root }}" &&
+      RAILS_ENV={{ project_app_env }}
+      /usr/local/bin/bundle exec rake vtul:geoblacklight:data_ingest
     name: GeoBlacklight Ingest
     state: present


### PR DESCRIPTION
The PATH used in cron jobs is more restricted than when running the
same commands directly from a login shell.  This was causing "bundle
exec" in the cron job to fail due to "bundle" not being on the PATH.
The fix here is to invoke the bundle command with an absolute pathname,
i.e., "/usr/local/bin/bundle exec".
