### PR TITLE
apt-key fails to verify SSL certificates

### DIFF
--- a/ansible/roles/nodejs/tasks/main.yml
+++ b/ansible/roles/nodejs/tasks/main.yml
@@ -1,8 +1,8 @@
 ---
+
 - name: import nodesource GPG key
-  apt_key:
-    url: https://deb.nodesource.com/gpgkey/nodesource.gpg.key
-    state: present
+  become: yes
+  shell: /usr/bin/curl https://deb.nodesource.com/gpgkey/nodesource.gpg.key | /usr/bin/apt-key add -
 
 - name: add nodesource deb repo
   apt_repository:


### PR DESCRIPTION
when using the apt-key module with python less that 2.7.9 SSL
verification fails. Ubuntu 14.04 has python 2.7.6 which makes
installation fail.
