### PR TITLE
Adds Python packages for apt-key to validate SNI certs.

### DIFF
--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -9,3 +9,13 @@
     - build-essential
     - apt-transport-https
     - python-apt
+    - python-pip
+
+- name: update python's crypto libs
+  pip:
+    name: '{{ item }}'
+  with_items:
+    - urllib3
+    - pyopenssl
+    - ndg-httpsclient
+    - pyasn1


### PR DESCRIPTION
Recently, NodeJS changed how they are using TLS on the server hosting their apt key. Now, in order to validate, the client must be capable of SNI. However, with versions of Python older than 2.7.9, Ansible's apt_key module is not able to preform SNI without the libraries added here. Ubuntu 14.04 uses Python 2.7.6
