### PR TITLE
Does not exclude gem groups when not in production mode.

### DIFF
--- a/ansible/roles/sufia/tasks/main.yml
+++ b/ansible/roles/sufia/tasks/main.yml
@@ -72,6 +72,7 @@
 - name: install the project's gems for development
   bundler:
     chdir: '{{ project_app_root }}'
+    exclude_groups: ''
   when: project_app_env != 'production'
 
 - name: install the project's gems for production


### PR DESCRIPTION
Fixes the LoadError for phantomjs/poltergeist when swtiching from production mode to development. From the Ansible docs: "Bundler considers [exclude groups] a 'remembered' property for the Gemfile and will automatically exclude groups in future operations even if exclude_groups is not set"
