### PR TITLE
Only installs Fedora, Solr, and Redis if they have local connections.

### DIFF
--- a/ansible/roles/sufia/tasks/main.yml
+++ b/ansible/roles/sufia/tasks/main.yml
@@ -53,6 +53,7 @@
 
 - name: create the project's solr cores
   include: solr_core_setup.yml
+  when: project_solr_url | search( 'localhost|127\.0\.0\.1' )
 
 - name: copy the secrets file
   template:

--- a/ansible/sufia_site.yml
+++ b/ansible/sufia_site.yml
@@ -6,10 +6,31 @@
     - site_secrets.yml
   gather_facts: true
   roles:
-    - { role: fedora4, become: yes, fedora_version: '4.5.1' }
-    - { role: solr, become: yes, solr_version: '5.5.1' }
-    - { role: postgresql, become: yes, postgres_version: '9.4' }
-    - { role: redis, become: yes }
-    - { role: sufia, become: yes }
+    - {
+        role: fedora4,
+        become: yes,
+        fedora_version: '4.5.1',
+        when: project_fedora_url | search( 'localhost|127\.0\.0\.1' )
+    }
+    - {
+        role: solr,
+        become: yes,
+        solr_version: '5.5.1',
+        when: project_solr_url | search( 'localhost|127\.0\.0\.1' )
+    }
+    - {
+        role: postgresql,
+        become: yes,
+        postgres_version: '9.4'
+    }
+    - {
+        role: redis,
+        become: yes,
+        when: project_redis_host | search( 'localhost|127\.0\.0\.1' )
+    }
+    - {
+        role: sufia,
+        become: yes
+    }
   environment:
     RAILS_ENV: '{{ project_app_env }}'


### PR DESCRIPTION
Connections need to be to 'localhost' or '127.0.0.1'. Support for IPv6 ('::1') is not implemented. Resque is still installed locally if it is present in the gems.
