### PR TITLE
Add Graylog logging to geoblacklight

### DIFF
--- a/ansible/example_site_secrets.yml
+++ b/ansible/example_site_secrets.yml
@@ -9,7 +9,7 @@ project_git_identifier: 'master'
 project_app_env: 'development'
 # Rails "secret_key_base:" setting in config/secrets.yml.
 # This MUST be set here if {{ project_app_env }} is set to "production"
-# it can be generated using `openssl rand -base64 64`
+# it can be generated using `openssl rand -hex 64`
 project_secret_key_base: ''
 
 # Multi-Role Project Variables:
@@ -20,6 +20,24 @@ project_user: 'hydra'
 project_user_home: '/var/local/{{ project_user }}'
 # Name of group to which {{ project_user }} belongs
 project_group: '{{ project_user }}'
+
+# Graylog logging
+#
+# If the project_app_env is "production" then you may want to enable Graylog
+# logging.  Here are applicable settings:
+#
+# Host running Graylog server
+graylog_host: 127.0.0.1
+# Port on which Graylog server is listening
+graylog_port: 12201
+# Protocol used by GELF input: 'udp' or 'tcp'
+graylog_protocol: udp
+# Chunking size appropriate for network between client and Graylog server: 'LAN' or 'WAN'
+graylog_network_locality: WAN
+# The facility identifying the client application
+graylog_facility: "{{ project_name }}"
+# Rails::Application::Configuration.log_level: "debug", "info", "warn", "error", etc.
+graylog_verbosity: "info"
 
 # Project Secrets:
 #

--- a/ansible/roles/geoblacklight/defaults/main.yml
+++ b/ansible/roles/geoblacklight/defaults/main.yml
@@ -2,3 +2,10 @@
 passenger_instances: '2'
 nginx_max_upload_size: '10m'
 project_solr_core: blacklight-core
+graylog_enable: "{{ 'true' if project_app_env == 'production' else 'false' }}"
+graylog_host: 127.0.0.1
+graylog_port: 12201
+graylog_protocol: udp
+graylog_network_locality: WAN
+graylog_facility: "{{ project_name }}"
+graylog_verbosity: "info"

--- a/ansible/roles/geoblacklight/templates/secrets.yml.j2
+++ b/ansible/roles/geoblacklight/templates/secrets.yml.j2
@@ -26,3 +26,11 @@ test:
 production:
   <<: *default
   secret_key_base: {{ project_secret_key_base }}
+  graylog:
+    enabled: {{ graylog_enable }}
+    host: "{{ graylog_host }}"
+    port: {{ graylog_port }}
+    network_locality: "{{ graylog_network_locality }}"
+    protocol: "{{ graylog_protocol }}"
+    facility: "{{ graylog_facility }}"
+    verbosity: "{{ graylog_verbosity }}"


### PR DESCRIPTION
Add a "graylog" key to config/secrets.yml for a geoblacklight
application.  This is intended to specify values used by code in the
geoblacklight config/environments/production.rb to set up logging to a
Graylog server in RAILS_ENV="production" mode.

Defaults settings are provided in geoblacklight/defaults/main.yml that
may be overridden by settings in site_secrets.yml (as documented in
example_site_secrets.yml) during Ansible provisioning.
