### PR TITLE
Support ClamAV PrivateMirrors

### DIFF
--- a/ansible/roles/clamav/README.md
+++ b/ansible/roles/clamav/README.md
@@ -11,9 +11,12 @@ The target system should have Apt, and our Common role.
 Role Variables
 --------------
 
-None
+Role variables are listed below:
+
+- `clamav_private_mirror_enabled`: Whether to enable a ClamAV PrivateMirror to override the included DatabaseMirror definitions (true/false)
+- `clamav_private_mirror_host`: The FQDN of the ClamAV PrivateMirror (string)
 
 Dependencies
 ------------
 
-None
+Our Common role

--- a/ansible/roles/clamav/defaults/main.yml
+++ b/ansible/roles/clamav/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+clamav_private_mirror_enabled: true
+clamav_private_mirror_host: clamav.mirror.cc.vt.edu

--- a/ansible/roles/clamav/tasks/main.yml
+++ b/ansible/roles/clamav/tasks/main.yml
@@ -8,6 +8,21 @@
     - clamav
     - libclamav-dev
 
+- name: use local private mirror if enabled
+  lineinfile:
+    dest: /etc/clamav/freshclam.conf
+    insertafter: EOF
+    line: PrivateMirror {{ clamav_private_mirror_host }}
+    state: present
+  when: clamav_private_mirror_enabled
+
+- name: disable local private mirror if not enabled
+  lineinfile:
+    dest: /etc/clamav/freshclam.conf
+    regexp: "PrivateMirror .*"
+    state: absent
+  when: not clamav_private_mirror_enabled
+
 - name: create/update the clamav databases
   command: /usr/bin/freshclam --quiet
   args:


### PR DESCRIPTION
Add support to explicitly add a PrivateMirror directive to
/etc/clamav/freshclam.conf if the Ansible setting
clamav_private_mirror_enabled is set to true.  If set to false, the
PrivateMirror option is removed from /etc/clamav/freshclam.conf.  The
Ansible setting clamav_private_mirror_host designates the hostname of
the PrivateMirror to be used.

The default is to enable the VT ClamAV PrivateMirror.  This should
speed up the initial freshclam invocation considerably.
