### PR TITLE
Fix FITS unarchiving in Ansible <2.2

### DIFF
--- a/ansible/roles/fits/tasks/main.yml
+++ b/ansible/roles/fits/tasks/main.yml
@@ -20,7 +20,7 @@
   unarchive:
     src: /tmp/fits-{{ fits_version }}.zip
     dest: /opt
-    remote_src: yes
+    copy: no
     creates: /opt/fits-{{ fits_version }}/fits.sh
 
 - name: ensure fits directory is accessible


### PR DESCRIPTION
The "remote_src" option to the unarchive Ansible module is not
available in the current Ansible 2.1 release.  Instead, the "copy"
option must be used.

We change to "copy: no" instead of "remote_src: yes" until the latter
becomes available in Ansible 2.2.
