### PR TITLE
Allow Fedora Java VM options to be specified

### DIFF
--- a/ansible/example_site_secrets.yml
+++ b/ansible/example_site_secrets.yml
@@ -63,6 +63,15 @@ project_db_password: 'changeme'
 project_solr_url: 'http://localhost:8983/solr'
 # Name of Solr core used by application
 project_solr_core: '{{ project_app_env }}'
+# Hostname at which Redis server can be contacted
+project_redis_host: 'localhost'
+# Port on which Redis server listens
+project_redis_port: '6379'
+# Base URL of CAS server endpoint
+project_cas_url: 'https://login-dev.middleware.vt.edu/profile/cas'
+
+# Fedora 4 settings
+#
 # Base URL of Fedora 4 endpoint
 project_fedora_url: 'http://127.0.0.1:8080/fedora/rest'
 # Servlet container username used to access Fedora 4
@@ -71,12 +80,8 @@ project_fedora_user: 'fedoraAdmin'
 project_fedora_password: 'fedoraAdmin'
 # Base path of Fedora 4 repository (e.g., "/prod", "/dev", "/test")
 project_fedora_base_path: '/prod'
-# Hostname at which Redis server can be contacted
-project_redis_host: 'localhost'
-# Port on which Redis server listens
-project_redis_port: '6379'
-# Base URL of CAS server endpoint
-project_cas_url: 'https://login-dev.middleware.vt.edu/profile/cas'
+# Java VM options
+project_fedora_java_vm_opts: '-Xms512m -Xmx1024m -XX:NewSize=256m -XX:MaxNewSize=256m -XX:MetaspaceSize=256m -XX:MaxMetaspaceSize=256m -XX:+DisableExplicitGC'
 
 # Multi-Role Solr Variables:
 #

--- a/ansible/roles/fedora4/README.md
+++ b/ansible/roles/fedora4/README.md
@@ -18,3 +18,7 @@ Role variables are listed below, along with their defaults:
     fedora_user_home: /var/local/tomcat7
     fedora_data_dir: /var/local/tomcat7/fedora-data
     fedora_app_dir: /var/lib/tomcat7/webapps
+    fedora_java_vm_opts: -Xms512m -Xmx1024m -XX:NewSize=256m -XX:MaxNewSize=256m -XX:MetaspaceSize=256m -XX:MaxMetaspaceSize=256m -XX:+DisableExplicitGC
+
+
+It should be noted that `fedora_java_vm_opts` is intended to define all memory-related Java VM options necessary to constrain the total amount of memory Tomcat may use.  As such, care should be exercised when changing `fedora_java_vm_opts`.  Omitting a setting in the string (e.g. `-Xms...`) will result in that Java VM option either to be unset or to revert to the default for the Java VM.  Users should exercise caution when deleting individual Java options from `fedora_java_vm_opts`. 

--- a/ansible/roles/fedora4/defaults/main.yml
+++ b/ansible/roles/fedora4/defaults/main.yml
@@ -4,3 +4,4 @@ fedora_group: '{{ fedora_user }}'
 fedora_user_home: '/var/local/{{ fedora_user }}'
 fedora_data_dir: '{{ fedora_user_home }}/fedora-data'
 fedora_app_dir: '/var/lib/tomcat7/webapps'
+fedora_java_vm_opts: "{{ project_fedora_java_vm_opts | default('-Xms512m -Xmx1024m -XX:NewSize=256m -XX:MaxNewSize=256m -XX:MetaspaceSize=256m -XX:MaxMetaspaceSize=256m -XX:+DisableExplicitGC') }}"

--- a/ansible/roles/fedora4/tasks/main.yml
+++ b/ansible/roles/fedora4/tasks/main.yml
@@ -34,5 +34,7 @@
 - name: add fedora and java config options to tomcat
   lineinfile:
     dest: /etc/default/tomcat7
-    line: JAVA_OPTS='-Dfcrepo.home={{ fedora_data_dir }} -Djava.awt.headless=true -Dfile.encoding=UTF-8 -server -Xms512m -Xmx1024m -XX:NewSize=256m -XX:MaxNewSize=256m -XX:MetaspaceSize=256m -XX:MaxMetaspaceSize=256m -XX:+DisableExplicitGC'
+    line: JAVA_OPTS='-Dfcrepo.home={{ fedora_data_dir }} -Djava.awt.headless=true -Dfile.encoding=UTF-8 -server {{ fedora_java_vm_opts }}'
+    regexp: "^JAVA_OPTS=.*"
+    state: present
   notify: restart tomcat


### PR DESCRIPTION
We introduce into the fedora4 role a new variable,
"fedora_java_vm_opts", that is used for specifying the VM-related
options (max heap size, etc.) to JAVA_OPTS.

This option is represented at the project level by the Ansible variable
"project_fedora_java_vm_opts".  By use of this variable, pre-production
and production servers can tailor the amount of memory available to
Fedora 4 via Tomcat.
