### PR TITLE
Add additional settings to define which ORCiD service is used

### DIFF
--- a/ansible/example_site_secrets.yml
+++ b/ansible/example_site_secrets.yml
@@ -53,6 +53,8 @@ project_ezid_password: 'apitest'
 project_orcid_app_id: '0000-0000-0000-0000'
 # ORCID API application secret
 project_orcid_app_secret: 'XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX'
+# Which ORCID service to use: sandbox or production
+project_orcid_service: 'sandbox'
 # Application database name for Rails config/database.yml "database:" setting
 project_db_name: 'datarepo'
 # Application database user for Rails config/database.yml "username:" setting

--- a/ansible/roles/sufia/defaults/main.yml
+++ b/ansible/roles/sufia/defaults/main.yml
@@ -11,3 +11,8 @@ project_deploy_key: ''
 project_app_root: '{{ project_user_home }}/{{ project_name }}'
 # Name of Solr test core used by application
 project_solr_test_core: 'test'
+# ORCID API endpoints
+project_orcid_site_url: "{{ 'http://api.orcid.org' if project_orcid_service == 'production' else 'http://api.sandbox.orcid.org' }}"
+project_orcid_token_url: "{{ 'https://api.orcid.org/oauth/token' if project_orcid_service == 'production' else 'https://api.sandbox.orcid.org/oauth/token' }}"
+project_orcid_remote_signin_url: "{{ 'https://orcid.org/signin/auth.json' if project_orcid_service == 'production' else 'https://sandbox.orcid.org/signin/auth.json' }}"
+project_orcid_authorize_url: "{{ 'https://orcid.org/oauth/authorize' if project_orcid_service == 'production' else 'https://sandbox.orcid.org/oauth/authorize' }}"

--- a/ansible/roles/sufia/templates/secrets.yml.j2
+++ b/ansible/roles/sufia/templates/secrets.yml.j2
@@ -30,6 +30,10 @@ default: &default
   orcid: &orcid
     app_id: {{ project_orcid_app_id }}
     app_secret: {{ project_orcid_app_secret }}
+    site_url: {{ project_orcid_site_url }}
+    token_url: {{ project_orcid_token_url }}
+    remote_signin_url: {{ project_orcid_remote_signin_url }}
+    authorize_url: {{ project_orcid_authorize_url }}
   redis: &redis
     host: {{ project_redis_host }}
     port: {{ project_redis_port }}


### PR DESCRIPTION
Here we add extra fields to the "orcid" key of the config/secrets.yml
template so that either the "sandbox" or "production" ORCiD services
may be used.

Which settings are used is governed by the "project_orcid_service"
entry in site_secrets.yml.  URLs corresponding to the production
service are used if "project_orcid_service" is set to "production".
Otherwise, settings appropriate for the sandbox service are used.
