### PR TITLE
Add project_max_upload_size Ansible variable

### DIFF
--- a/ansible/example_site_secrets.yml
+++ b/ansible/example_site_secrets.yml
@@ -108,6 +108,8 @@ project_git_url: 'https://github.com/VTUL/{{ project_name }}.git'
 project_deploy_key: ''
 # The directory in which the application will reside
 project_app_root: '{{project_user_home }}/{{ project_name }}'
+# Max upload size
+#project_max_upload_size: "200m"
 # Username for chroot SFTP user
 sftp_user: "upload"
 # Username that should be the primary owner of the chroot SFTP directory area

--- a/ansible/roles/geoblacklight/defaults/main.yml
+++ b/ansible/roles/geoblacklight/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 passenger_instances: '2'
-nginx_max_upload_size: '10m'
+nginx_max_upload_size: "{{ project_max_upload_size|default('10m') }}"
 project_solr_core: blacklight-core
 graylog_enable: "{{ 'true' if project_app_env == 'production' else 'false' }}"
 graylog_host: 127.0.0.1

--- a/ansible/roles/sufia/defaults/main.yml
+++ b/ansible/roles/sufia/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 passenger_instances: 2
-nginx_max_upload_size: "200m"
+nginx_max_upload_size: "{{ project_max_upload_size|default('200m') }}"
 tls_cert_subject: "/C=US/ST=Virginia/O=Virginia Tech/localityName=Blacksburg/commonName={{ ansible_fqdn }}/organizationalUnitName=University Libraries"
 tls_cert_dir: /etc/ssl/local/certs
 tls_cert_file: cert.pem


### PR DESCRIPTION
We add a project_max_upload_size variable that can be set in
site_secrets.yml to control the maximum upload size.
