### PR TITLE
Gather local files under local_files

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,13 +33,17 @@ For all environments, a deployment settings file needs to be created in the `ans
 cp example_site_secrets.yml site_secrets.yml
 ```
 
-The Ansible playbook will be expecting a repository-ignored `site_secrets.yml` YAML file. Read the variable contents of the file and adjust accordingly to match your local environment.
+The Ansible playbook will be expecting a repository-ignored `site_secrets.yml` YAML file. Read the variable contents of the file and adjust accordingly to match your local environment. All configurable aspects of the application to be deployed may be altered by changing settings in this file.
 
 #### TLS certificate and key
 
 A TLS certificate and key file may be placed in the `local_files/` directory for use in the system being set up. The certificate should be named `local_files/cert.pem` and the key named `local_files/key.pem`.
 
 If either of the aforementioned files is not present then a self-signed TLS certificate and key pair will be generated and used instead.
+
+#### Local files
+
+Sometimes, local files may be supplied during the deployment or provisioning of a target application, e.g., carousel images for the `data-repo` application, TLS key files, etc. Such local (and potentially sensitive) files should be placed in the `local_files` directory. The contents of the `local_files` directory hierarchy are subject to `.gitignore` and so won't be checked in via Git accidentally.
 
 #### Authorized keys for SFTP
 
@@ -73,7 +77,7 @@ When using the `aws` provider to `vagrant up` it is necessary to define several 
 - `AWS_SECRET_KEY`: the AWS IAM secret key to the account under which the EC2 instance will be created.
 - `AWS_SECURITY_GROUPS`: a space-separated list of existing AWS security groups to apply to this instance. (If `AWS_SECURITY_GROUPS` is not set then a default security group is used.)
 
-WARNING: Many of the other AWS EC2 instance settings (e.g., instance type) are set directly in the `Vagrantfile` and make sense only for VTUL users. Please check these are appropriate before bringing up the instance with Vagrant and edit where necessary beforehand.
+WARNING: Many of the other AWS EC2 instance settings (e.g., instance type) are set directly in the `Vagrantfile` and make sense only for VTUL users. Please check these are appropriate before bringing up the instance with Vagrant and edit where necessary beforehand. Note that for the `aws` provider to work the AWS account should have a default VPC defined in it.
 
 ### OpenStack
 

--- a/ansible/roles/phantomjs/README.md
+++ b/ansible/roles/phantomjs/README.md
@@ -19,3 +19,5 @@ Role variables are listed below, along with their defaults:
     phantomjs_dir: '{{ project_user_home }}/.phantomjs/{{ phantomjs_version }}/{{ phantomjs_arch }}-{{ phantomjs_distro }}'
 
 Additionally, when using this role, you must pass in the `phantomjs_version`.
+
+This role makes use of the `local_files_dir` variable defined in the top-level `site_vars.yml` file. The `local_files_dir` setting points to a local directory on the provisioning host where locally-provided files may be supplied to the deployment and provisioning process. In the case of the `phantomjs` role, this directory is used to supply (and cache) a copy of the PhantomJS distribution, to avoid excessive downloads.

--- a/ansible/roles/phantomjs/tasks/main.yml
+++ b/ansible/roles/phantomjs/tasks/main.yml
@@ -7,7 +7,7 @@
 
   - name: copy cached phantomjs
     copy:
-      src: '{{ phantomjs_src }}'
+      src: '{{ local_files_dir }}/{{ phantomjs_src }}'
       dest: /tmp/{{ phantomjs_src }}
     register: cached_pjs
     ignore_errors: True
@@ -28,6 +28,6 @@
 - name: cache phantomjs for the future
   fetch:
     src: /tmp/{{ phantomjs_src }}
-    dest: '{{ role_path }}/files/'
+    dest: '{{ local_files_dir }}/'
     flat: True
   when: ansible_virtualization_type == 'virtualbox'

--- a/ansible/roles/sufia/README.md
+++ b/ansible/roles/sufia/README.md
@@ -26,3 +26,5 @@ Role variables are listed below, along with their defaults:
     project_deploy_key: ''
     project_app_root: '{{ project_user_home }}/{{ project_name }}'
     project_solr_test_core: test
+
+This role makes use of the `local_files_dir` variable defined in the top-level `site_vars.yml` file. The `local_files_dir` setting points to a local directory on the provisioning host where locally-provided files may be supplied to the deployment and provisioning process. In the case of the `sufia` role, this directory is used to supply the `user_list.txt`, `admin_list.txt`, and `images.zip` carousel images for the `data-repo` application.

--- a/ansible/roles/sufia/defaults/main.yml
+++ b/ansible/roles/sufia/defaults/main.yml
@@ -1,11 +1,6 @@
 ---
 passenger_instances: 2
 nginx_max_upload_size: "{{ project_max_upload_size|default('200m') }}"
-tls_cert_subject: "/C=US/ST=Virginia/O=Virginia Tech/localityName=Blacksburg/commonName={{ ansible_fqdn }}/organizationalUnitName=University Libraries"
-tls_cert_dir: /etc/ssl/local/certs
-tls_cert_file: cert.pem
-tls_key_dir: /etc/ssl/local/private
-tls_key_file: key.pem
 project_git_url: https://github.com/VTUL/{{ project_name }}.git
 project_deploy_key: ''
 project_app_root: '{{ project_user_home }}/{{ project_name }}'

--- a/ansible/roles/sufia/meta/main.yml
+++ b/ansible/roles/sufia/meta/main.yml
@@ -4,6 +4,7 @@ dependencies:
   - { role: common }
   - { role: fits }
   - { role: passenger }
+  - { role: tls_cert }
   - { role: clamav }
   - { role: ffmpeg }
   - { role: postfix }

--- a/ansible/roles/sufia/tasks/data-repo.yml
+++ b/ansible/roles/sufia/tasks/data-repo.yml
@@ -7,7 +7,7 @@
 
   - name: copy list of users
     copy:
-      src: user_list.txt
+      src: "{{ local_files_dir }}/user_list.txt"
       dest: '{{ project_app_root }}/user_list.txt'
     ignore_errors: True
     register: copy_user_list
@@ -25,7 +25,7 @@
 
   - name: copy list of admins
     copy:
-      src: admin_list.txt
+      src: "{{ local_files_dir }}/admin_list.txt"
       dest: '{{ project_app_root }}/admin_list.txt'
     ignore_errors: True
     register: copy_admin_list
@@ -43,7 +43,7 @@
 
   - name: copy zipped images
     copy:
-      src: images.zip
+      src: "{{ local_files_dir }}/images.zip"
       dest: '{{ project_app_root }}/images.zip'
     ignore_errors: True
     register: copy_zipped_images

--- a/ansible/roles/sufia/tasks/passenger_setup.yml
+++ b/ansible/roles/sufia/tasks/passenger_setup.yml
@@ -8,54 +8,6 @@
   notify: restart nginx
   when: ansible_virtualization_type == 'virtualbox'
 
-- name: ensure tls cert and key directories exist
-  file:
-    path: '{{ item }}'
-    state: directory
-  with_items:
-    - '{{ tls_cert_dir }}'
-    - '{{ tls_key_dir }}'
-
-- name: copy existing tls files, if present.
-  copy:
-    src: '{{ item.source }}'
-    dest: '{{ item.dest }}'
-  register: reuse_tls_files
-  ignore_errors: True
-  notify: restart nginx
-  with_items:
-    - source: '{{ tls_cert_file }}'
-      dest: '{{ tls_cert_dir }}/{{ tls_cert_file }}'
-    - source: '{{ tls_key_file }}'
-      dest: '{{ tls_key_dir }}/{{ tls_key_file }}'
-
-- name: generate self-signed tls certificate
-  command: openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout "{{ tls_key_dir }}/{{ tls_key_file }}" -out "{{ tls_cert_dir }}/{{ tls_cert_file }}" -subj "{{ tls_cert_subject }}"
-  args:
-    chdir: /tmp
-  when: reuse_tls_files|failed
-  notify: restart nginx
-
-- name: copy tls cert and key for reuse in vagrant
-  fetch:
-    src: '{{ item }}'
-    dest: '{{ role_path }}/files/'
-    flat: True
-  with_items:
-    - '{{ tls_cert_dir }}/{{ tls_cert_file }}'
-    - '{{ tls_key_dir }}/{{ tls_key_file }}'
-  when: ansible_virtualization_type == 'virtualbox'
-
-- name: set tls file permissions
-  file:
-    path: '{{ item.path }}'
-    mode: '{{ item.mode }}'
-  with_items:
-    - path: '{{ tls_cert_dir }}/{{ tls_cert_file }}'
-      mode: '0444'
-    - path: '{{ tls_key_dir }}/{{ tls_key_file }}'
-      mode: '0400'
-
 - name: copy project passenger site
   template:
     src: passenger.site.j2

--- a/ansible/roles/tls_cert/README.md
+++ b/ansible/roles/tls_cert/README.md
@@ -26,3 +26,5 @@ Role variables are listed below:
 - `tls_key_file`: The filename of the TLS certificate private key.
 
 See `defaults/main.yml` for current default settings.
+
+This role makes use of the `local_files_dir` variable defined in the top-level `site_vars.yml` file. The `local_files_dir` setting points to a local directory on the provisioning host where locally-provided files may be supplied to the deployment and provisioning process. In the case of the `tls_cert` role, this directory may be used to supply a local TLS public and private key.

--- a/ansible/roles/tls_cert/tasks/main.yml
+++ b/ansible/roles/tls_cert/tasks/main.yml
@@ -11,16 +11,18 @@
 
 - name: copy local tls certificate if present
   copy:
-    src: "{{ tls_local_files_dir }}/cert.pem"
+    src: "{{ tls_local_files_dir }}/{{ tls_cert_file }}"
     dest: "{{ tls_cert_dir }}/{{ tls_cert_file }}"
   register: local_cert
+  notify: restart nginx
   ignore_errors: True
 
 - name: copy local tls key if present
   copy:
-    src: "{{ tls_local_files_dir }}/key.pem"
+    src: "{{ tls_local_files_dir }}/{{ tls_key_file }}"
     dest: "{{ tls_key_dir }}/{{ tls_key_file }}"
   register: local_key
+  notify: restart nginx
   ignore_errors: True
 
 - name: generate self-signed tls certificate if necessary
@@ -31,7 +33,18 @@
       -subj "{{ tls_cert_subject }}"
   args:
     chdir: /tmp
+  notify: restart nginx
   when: local_cert|failed or local_key|failed
+
+- name: copy tls cert and key for reuse in vagrant
+  fetch:
+    src: '{{ item }}'
+    dest: '{{ tls_local_files_dir }}/'
+    flat: True
+  with_items:
+    - '{{ tls_cert_dir }}/{{ tls_cert_file }}'
+    - '{{ tls_key_dir }}/{{ tls_key_file }}'
+  when: ansible_virtualization_type == 'virtualbox'
 
 - name: set tls file permissions
   file:

--- a/ansible/sufia_site.yml
+++ b/ansible/sufia_site.yml
@@ -3,6 +3,7 @@
   hosts: all
   user: "{{ ansible_user }}"
   vars_files:
+    - site_vars.yml
     - site_secrets.yml
   gather_facts: true
   roles:


### PR DESCRIPTION
We aim for the convention that locally-provided files should go under
the local_files directory in the Ansible playbook directory (ansible/).
