### PR TITLE
Add Graylog logging to sufia

### DIFF
--- a/ansible/roles/sufia/defaults/main.yml
+++ b/ansible/roles/sufia/defaults/main.yml
@@ -11,3 +11,11 @@ project_orcid_site_url: "{{ 'http://api.orcid.org' if project_orcid_service == '
 project_orcid_token_url: "{{ 'https://api.orcid.org/oauth/token' if project_orcid_service == 'production' else 'https://api.sandbox.orcid.org/oauth/token' }}"
 project_orcid_remote_signin_url: "{{ 'https://orcid.org/signin/auth.json' if project_orcid_service == 'production' else 'https://sandbox.orcid.org/signin/auth.json' }}"
 project_orcid_authorize_url: "{{ 'https://orcid.org/oauth/authorize' if project_orcid_service == 'production' else 'https://sandbox.orcid.org/oauth/authorize' }}"
+# Graylog production logging defaults
+graylog_enable: "{{ 'true' if project_app_env == 'production' else 'false' }}"
+graylog_host: 127.0.0.1
+graylog_port: 12201
+graylog_protocol: udp
+graylog_network_locality: WAN
+graylog_facility: "{{ project_name }}"
+graylog_verbosity: "info"

--- a/ansible/roles/sufia/templates/secrets.yml.j2
+++ b/ansible/roles/sufia/templates/secrets.yml.j2
@@ -72,3 +72,11 @@ test:
 production:
   <<: *default
   secret_key_base: {{ project_secret_key_base }}
+  graylog:
+    enabled: {{ graylog_enable }}
+    host: "{{ graylog_host }}"
+    port: {{ graylog_port }}
+    network_locality: "{{ graylog_network_locality }}"
+    protocol: "{{ graylog_protocol }}"
+    facility: "{{ graylog_facility }}"
+    verbosity: "{{ graylog_verbosity }}"


### PR DESCRIPTION
Add a "graylog" key to config/secrets.yml for a sufia
application. This is intended to specify values used by code in the
sufia config/environments/production.rb to set up logging to a
Graylog server in RAILS_ENV="production" mode.

Defaults settings are provided in sufia/defaults/main.yml that
may be overridden by settings in site_secrets.yml (as documented in
example_site_secrets.yml) during Ansible provisioning.
