### PR TITLE
Prefer ansible over ansible_local

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -49,6 +49,10 @@ def vagrant_ansible_provisioner
   if prov == "ansible" or prov == "ansible_local"
     return prov
   else
+    if system( 'which ansible' )
+      return :ansible
+    end
+
     return :ansible_local
   end
 end


### PR DESCRIPTION
If Ansible is installed, use it, rather than the ansible_local provisioner.
