### PR TITLE
Caches the NOID minter statefile [WIP]

### DIFF
--- a/ansible/roles/sufia/tasks/data-repo.yml
+++ b/ansible/roles/sufia/tasks/data-repo.yml
@@ -63,6 +63,18 @@
       dest: '{{ project_app_root }}/app/assets/images/carousel/'
     ignore_errors: True
 
+  - name: find NOID minter statefile
+    stat:
+      path: /tmp/minter-state
+    register: noid_state
+
+  - name: cache NOID minter statefile
+    fetch:
+      src: /tmp/minter-state
+      dest: '{{ local_files_dir }}/'
+      flat: True
+    when: noid_state.stat.exists
+
   become: yes
   become_user: '{{ project_user }}'
   environment:


### PR DESCRIPTION
The statefile is responsible for preventing ID collisions when creating objects. By caching it, we can avoid ID collisions. This is only really an issue for production and preprod.