### PR TITLE
Add OpenJDK8 role and switch to using it instead of Oracle Java 8

### DIFF
--- a/ansible/roles/openjdk8/README.md
+++ b/ansible/roles/openjdk8/README.md
@@ -1,0 +1,14 @@
+OpenJDK8
+=========
+
+Installs OpenJDK 8 via the openjdk-r PPA repository due to OpenJDK not being available in Ubuntu 14.04.
+
+Requirements
+------------
+
+Apt must be installed, along with our Common role.
+
+Role Variables
+--------------
+
+None

--- a/ansible/roles/openjdk8/meta/main.yml
+++ b/ansible/roles/openjdk8/meta/main.yml
@@ -1,4 +1,3 @@
 ---
 dependencies:
   - { role: common }
-  - { role: openjdk8 }

--- a/ansible/roles/openjdk8/tasks/main.yml
+++ b/ansible/roles/openjdk8/tasks/main.yml
@@ -1,0 +1,10 @@
+---
+- name: Add OpenJDK-r Repository
+  apt_repository:
+    repo: 'ppa:openjdk-r/ppa'
+
+- name: Install OpenJDK8
+  apt:
+    name: openjdk-8-jdk
+    update_cache: yes
+    state: latest

--- a/ansible/roles/solr/README.md
+++ b/ansible/roles/solr/README.md
@@ -6,7 +6,7 @@ Installs Solr.
 Requirements
 ------------
 
-Solr is a Java application and so requires our Java8 role
+Solr is a Java application and so requires our OpenJDK8 role
 
 Role Variables
 --------------

--- a/ansible/roles/solr/meta/main.yml
+++ b/ansible/roles/solr/meta/main.yml
@@ -1,3 +1,3 @@
 ---
 dependencies:
-  - { role: java8 }
+  - { role: openjdk8 }

--- a/ansible/roles/tomcat7/tasks/main.yml
+++ b/ansible/roles/tomcat7/tasks/main.yml
@@ -13,10 +13,10 @@
     dest: /etc/tomcat7/server.xml
     mode: 0644
 
-- name: add line to use oracle-java-8
+- name: add line to use openjdk-8
   lineinfile:
     dest: /etc/default/tomcat7
-    line: "JAVA_HOME=/usr/lib/jvm/java-8-oracle"
+    line: "JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64"
 
 - name: ensure tomcat7 starts on boot
   service:


### PR DESCRIPTION
Due to occasional transient difficulties in installing Oracle Java 8,
this change adds a role to install OpenJDK 8 and use that in
Java-dependent roles instead.

Because OpenJDK 8 is not available in mainstream Ubuntu Trusty, we
install it via the openjdk-r PPA instead.