### PR TITLE
Suppress output of 'which ansible' when deciding provisioner

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -49,7 +49,7 @@ def vagrant_ansible_provisioner
   if prov == "ansible" or prov == "ansible_local"
     return prov
   else
-    if system( 'which ansible' )
+    if system( 'which ansible > /dev/null' )
       return :ansible
     end
 


### PR DESCRIPTION
The command 'which ansible' outputs the pathname of the ansible binary
(if present) to stdout.  To avoid this, we redirect output of the
'which ansible' command to /dev/null.