### PR TITLE
Provide key IDs for APT keys added via apt_key

### DIFF
--- a/ansible/roles/nodejs/tasks/main.yml
+++ b/ansible/roles/nodejs/tasks/main.yml
@@ -2,6 +2,7 @@
 - name: import nodesource GPG key
   apt_key:
     url: https://deb.nodesource.com/gpgkey/nodesource.gpg.key
+    id: 9FD3B784BC1C6FC31A8A0A1C1655A0AB68576280
     state: present
 
 - name: add nodesource deb repo

--- a/ansible/roles/postgresql/tasks/main.yml
+++ b/ansible/roles/postgresql/tasks/main.yml
@@ -2,6 +2,7 @@
 - name: add postgresql key
   apt_key:
     url: https://www.postgresql.org/media/keys/ACCC4CF8.asc
+    id: B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8
     state: present
 
 - name: add postgresql repository


### PR DESCRIPTION
This is so as to follow the comment in the Ansible documentation for
the `apt_key` module that states, "best practice is to specify the key
id and the url."