### PR TITLE
Restart application when config/secrets.yml changes

### DIFF
--- a/ansible/roles/sufia/tasks/main.yml
+++ b/ansible/roles/sufia/tasks/main.yml
@@ -61,6 +61,8 @@
     dest: '{{ project_app_root }}/config/secrets.yml'
     owner: '{{ project_user }}'
     group: '{{ project_group }}'
+  notify:
+    - restart nginx
 
 - name: make sure project user owns application
   file:


### PR DESCRIPTION
A change in config/secrets.yml could conceivably affect the
application, so we restart the application when this happens.