### PR TITLE
Change APT caching behaviour for Ansible 2.2

### DIFF
--- a/ansible/roles/clamav/tasks/main.yml
+++ b/ansible/roles/clamav/tasks/main.yml
@@ -3,6 +3,7 @@
   apt:
     name: '{{ item }}'
     state: present
+    cache_valid_time: '{{ apt_cache_timeout }}'
     update_cache: yes
   with_items:
     - clamav

--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -3,6 +3,7 @@
   apt:
     name: '{{ item }}'
     state: present
+    cache_valid_time: '{{ apt_cache_timeout }}'
     update_cache: yes
   with_items:
     - acl

--- a/ansible/roles/ffmpeg/tasks/main.yml
+++ b/ansible/roles/ffmpeg/tasks/main.yml
@@ -2,9 +2,12 @@
 - name: add repository
   apt_repository:
     repo: 'ppa:mc3man/trusty-media'
+    state: present
+    update_cache: yes
 
 - name: install ffmpeg
   apt:
     name: ffmpeg
+    cache_valid_time: '{{ apt_cache_timeout }}'
     update_cache: yes
     state: present

--- a/ansible/roles/fits/tasks/main.yml
+++ b/ansible/roles/fits/tasks/main.yml
@@ -3,6 +3,7 @@
   apt:
     name: "{{ item }}"
     state: present
+    cache_valid_time: '{{ apt_cache_timeout }}'
     update_cache: yes
   with_items:
     - unzip

--- a/ansible/roles/geoblacklight/tasks/main.yml
+++ b/ansible/roles/geoblacklight/tasks/main.yml
@@ -3,6 +3,7 @@
   apt:
     name: '{{ item }}'
     state: present
+    cache_valid_time: '{{ apt_cache_timeout }}'
     update_cache: yes
   with_items:
     - git

--- a/ansible/roles/java8/tasks/main.yml
+++ b/ansible/roles/java8/tasks/main.yml
@@ -2,6 +2,8 @@
 - name: Add Oracle Java Repository
   apt_repository:
     repo: 'ppa:webupd8team/java'
+    state: present
+    update_cache: yes
 
 - name: Accept Java 8 License
   debconf:
@@ -13,6 +15,7 @@
 - name: Install Oracle Java 8 and set as default
   apt:
     name: '{{ item }}'
+    cache_valid_time: '{{ apt_cache_timeout }}'
     update_cache: yes
     state: latest
   with_items:

--- a/ansible/roles/nodejs/tasks/main.yml
+++ b/ansible/roles/nodejs/tasks/main.yml
@@ -9,9 +9,11 @@
   apt_repository:
     repo: 'deb https://deb.nodesource.com/node_{{ nodejs_version }} {{ ansible_distribution_release }} main'
     state: present
+    update_cache: yes
 
 - name: install nodejs
   apt:
     name: nodejs
     state: present
+    cache_valid_time: '{{ apt_cache_timeout }}'
     update_cache: yes

--- a/ansible/roles/openjdk8/tasks/main.yml
+++ b/ansible/roles/openjdk8/tasks/main.yml
@@ -2,9 +2,12 @@
 - name: Add OpenJDK-r Repository
   apt_repository:
     repo: 'ppa:openjdk-r/ppa'
+    state: present
+    update_cache: yes
 
 - name: Install OpenJDK8
   apt:
     name: openjdk-8-jdk
+    cache_valid_time: '{{ apt_cache_timeout }}'
     update_cache: yes
     state: latest

--- a/ansible/roles/passenger/tasks/main.yml
+++ b/ansible/roles/passenger/tasks/main.yml
@@ -9,11 +9,13 @@
   apt_repository:
     repo: 'deb https://oss-binaries.phusionpassenger.com/apt/passenger {{ansible_distribution_release}} main'
     state: present
+    update_cache: yes
 
 - name: nginx and passenger installation
   apt:
     name: '{{ item }}'
     state: present
+    cache_valid_time: '{{ apt_cache_timeout }}'
     update_cache: yes
   with_items:
     - nginx-extras

--- a/ansible/roles/postfix/tasks/main.yml
+++ b/ansible/roles/postfix/tasks/main.yml
@@ -15,6 +15,7 @@
   apt:
     name: '{{ item }}'
     state: present
+    cache_valid_time: '{{ apt_cache_timeout }}'
     update_cache: yes
   with_items:
     - postfix

--- a/ansible/roles/postgresql/tasks/main.yml
+++ b/ansible/roles/postgresql/tasks/main.yml
@@ -8,12 +8,14 @@
 - name: add postgresql repository
   apt_repository:
     repo: 'deb http://apt.postgresql.org/pub/repos/apt/ {{ ansible_distribution_release }}-pgdg main'
+    update_cache: yes
     state: present
 
 - name: install postgresql packages
   apt:
     name: '{{ item }}'
     state: present
+    cache_valid_time: '{{ apt_cache_timeout }}'
     update_cache: yes
   with_items:
     - postgresql-{{ postgres_version }}

--- a/ansible/roles/redis/tasks/main.yml
+++ b/ansible/roles/redis/tasks/main.yml
@@ -3,6 +3,7 @@
   apt:
     name: redis-server
     state: present
+    cache_valid_time: '{{ apt_cache_timeout }}'
     update_cache: yes
 
 - name: configure redis

--- a/ansible/roles/ruby/tasks/main.yml
+++ b/ansible/roles/ruby/tasks/main.yml
@@ -2,11 +2,14 @@
 - name: add Brightbox repository
   apt_repository:
     repo: 'ppa:brightbox/ruby-ng'
+    update_cache: yes
+    state: present
 
 - name: install Brightbox Ruby package
   apt:
     name: '{{ item }}'
     state: present
+    cache_valid_time: '{{ apt_cache_timeout }}'
     update_cache: yes
   with_items:
     - ruby{{ ruby_version | default('2.3') }}

--- a/ansible/roles/sufia/tasks/main.yml
+++ b/ansible/roles/sufia/tasks/main.yml
@@ -3,6 +3,7 @@
   apt:
     name: '{{ item }}'
     state: present
+    cache_valid_time: '{{ apt_cache_timeout }}'
     update_cache: yes
   with_items:
     - git

--- a/ansible/roles/tomcat7/tasks/main.yml
+++ b/ansible/roles/tomcat7/tasks/main.yml
@@ -2,6 +2,8 @@
 - name: ensure tomcat7 packages are installed
   apt:
     name: '{{ item }}'
+    cache_valid_time: '{{ apt_cache_timeout }}'
+    update_cache: yes
     state: present
   with_items:
     - tomcat7

--- a/ansible/site_vars.yml
+++ b/ansible/site_vars.yml
@@ -1,2 +1,3 @@
 ---
 local_files_dir: "{{ playbook_dir }}/local_files"
+apt_cache_timeout: 1800


### PR DESCRIPTION
With Ansible 2.2, tasks that use the "apt" module now appear to update
the APT cache unconditionally when used with the "update_cache: yes"
option.  A side-effect of this is that the task is always flagged as
"changed" during an Ansible playbook run.  This "changed" status
applies even if no new packages are installed by the "apt" module.  In
a sense, such "changed" statuses can be seen as false positives in the
PLAY RECAP tally.

This pull request change is twofold:

1) It adds "update_cache: yes" options to tasks using "apt_repository",
where arguably they are more needed.  The "update_cache" option appears
to act more sensibly with "apt_repository" in that the status of
"changed" is applied and the APT update only done if the APT repository
is actually added/updated.

2) we add a "cache_valid_time" option to tasks using the "apt" module
so that an "apt update" requested by "update_cache: yes" is only
performed if the APT cache is older than "apt_cache_timeout" seconds.
The "apt_cache_timeout" value is a global set in ansible/site_vars.yml
and defaults to 30 minutes.  This means "update_cache: yes" will no
longer fire unconditionally, meaning tasks using the "apt" module will
not always register as "changed", even when no actual packages were
installed (e.g., on a re-provision).

With this change, the total number of "changed" statuses was reduced
from 17 to 5 on a re-provision without any explicit changes (restoring
the previous Ansible 2.1 behaviour).

Note: by setting "apt_cache_timeout" to a very short amount (e.g., 1
second), the effect of unconditional APT updates may be restored, if
desired.