### PR TITLE
Fix missing handler

### DIFF
--- a/ansible/roles/chroot-sftp/handlers/main.yml
+++ b/ansible/roles/chroot-sftp/handlers/main.yml
@@ -1,3 +1,4 @@
 ---
 - name: reload ssh configuration
   service: name=ssh state=reloaded
+  become: yes


### PR DESCRIPTION
With the release of Ansible 2.2, handlers were changed explicitly to
run as root when restarting system services.  The handler in the
chroot-sftp role was inadvertently left out in those updated as part of
pull request #114.  This commit rectifies that.