### PR TITLE
Fix Passenger setup

### DIFF
--- a/ansible/roles/geoblacklight/tasks/nginx_setup.yml
+++ b/ansible/roles/geoblacklight/tasks/nginx_setup.yml
@@ -8,6 +8,6 @@
 - name: enable passenger site
   file:
     src: /etc/nginx/sites-available/{{ project_name }}.site
-    dest: /etc/nginx/sites-enabled/{{ project_name }}.site
+    dest: /etc/nginx/sites-enabled/passenger.site
     state: link
   notify: restart nginx

--- a/ansible/roles/sufia/tasks/passenger_setup.yml
+++ b/ansible/roles/sufia/tasks/passenger_setup.yml
@@ -17,6 +17,6 @@
 - name: enable project passenger site
   file:
     src: /etc/nginx/sites-available/{{ project_name }}.site
-    dest: /etc/nginx/sites-enabled/{{ project_name }}.site
+    dest: /etc/nginx/sites-enabled/passenger.site
     state: link
   notify: restart nginx


### PR DESCRIPTION
The current Nginx Passenger setup is designed to work with only a
single Rails application.  Because sites-enabled currently uses
{{project_name}} it is possible to get multiple Passenger sites enabled
if the project_name is changed.  This, in turn, will cause Nginx to
fail to start because of complaints about multiply-defined
Passenger-related settings.

This change uses a single Passenger site name in sites-enabled, thereby
enforcing only one to the enabled at any given time when deployed via
these Ansible scripts.