### PR TITLE
Support local or remote PostgreSQL servers for Rails DB

### DIFF
--- a/ansible/example_site_secrets.yml
+++ b/ansible/example_site_secrets.yml
@@ -61,6 +61,12 @@ project_db_name: 'datarepo'
 project_db_user: '{{ project_user }}'
 # Application database name for Rails config/database.yml "password:" setting
 project_db_password: 'changeme'
+# Host of PostgreSQL server
+project_db_host: '/var/run/postgresql'
+# PostgreSQL admin user name for non-local db creation
+project_db_admin_user: postgres
+# PostgreSQL admin password for non-local db creation
+project_db_admin_password: postgres
 # Base URL of Solr endpoint
 project_solr_url: 'http://localhost:8983/solr'
 # Name of Solr core used by application

--- a/ansible/roles/postgresql/README.md
+++ b/ansible/roles/postgresql/README.md
@@ -11,8 +11,12 @@ Apt must be installed, along with our Common role.
 Role Variables
 --------------
 
-While the role does not have any variables itself, there are three in `site_secrets.yml`:
+While the role does not have many variables itself, there are these defined in in `site_secrets.yml`:
 
-    database_user: postgres
-    database_group: postgres
-    database_password: postgres
+- `database_user`: postgres
+- `database_group`: postgres
+- `database_password`: postgres
+
+The role variable below determines whether the PostgreSQL server used is to be installed and run locally on this server or whether it already exists on a remote server:
+
+- `postgresql_is_local`: true if `project_db_host` indicates the PostgreSQL host is on localhost or a Unix socket; false otherwise

--- a/ansible/roles/postgresql/defaults/main.yml
+++ b/ansible/roles/postgresql/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+# PostgreSQL-related settings
+postgresql_is_local: "{{ 'true' if project_db_host | search( 'localhost|127\\.0\\.0\\.1|^/') else 'false' }}"

--- a/ansible/roles/postgresql/handlers/main.yml
+++ b/ansible/roles/postgresql/handlers/main.yml
@@ -4,3 +4,4 @@
     name: postgresql
     state: restarted
   become: yes
+  when: postgres_is_local

--- a/ansible/roles/postgresql/tasks/main.yml
+++ b/ansible/roles/postgresql/tasks/main.yml
@@ -11,7 +11,7 @@
     update_cache: yes
     state: present
 
-- name: install postgresql packages
+- name: install postgresql server packages
   apt:
     name: '{{ item }}'
     state: present
@@ -19,21 +19,32 @@
     update_cache: yes
   with_items:
     - postgresql-{{ postgres_version }}
+  when: postgresql_is_local
+
+- name: install postgresql client packages
+  apt:
+    name: '{{ item }}'
+    state: present
+    cache_valid_time: '{{ apt_cache_timeout }}'
+    update_cache: yes
+  with_items:
     - libpq-dev
     - python-psycopg2
 
-- name: configure md5 security
+- name: install access rules
   copy:
     src: pg_hba.conf
     dest: /etc/postgresql/{{ postgres_version }}/main/pg_hba.conf
     group: '{{ database_group }}'
     owner: '{{ database_user }}'
   register: configure_postgres
+  when: postgresql_is_local
 
 - name: ensure postgres starts on boot
   service:
     name: postgresql
     enabled: yes
+  when: postgresql_is_local
 
 - name: restart postgres server
   service:

--- a/ansible/roles/sufia/README.md
+++ b/ansible/roles/sufia/README.md
@@ -28,3 +28,12 @@ Role variables are listed below, along with their defaults:
     project_solr_test_core: test
 
 This role makes use of the `local_files_dir` variable defined in the top-level `site_vars.yml` file. The `local_files_dir` setting points to a local directory on the provisioning host where locally-provided files may be supplied to the deployment and provisioning process. In the case of the `sufia` role, this directory is used to supply the `user_list.txt`, `admin_list.txt`, and `images.zip` carousel images for the `data-repo` application.
+
+The Sufia role also uses several variables that are normally defined in `site_secrets.yml`:
+
+- `project_db_name`: application database name for Rails config/database.yml `database:` setting
+- `project_db_user`: application database user for Rails config/database.yml `username:` setting
+- `project_db_password`: application database name for Rails config/database.yml `password:` setting
+- `project_db_host`: host of PostgreSQL server, used as application host name for Rails config/database.yml `host:` setting. This should be set to `/var/run/postgresql` to use a Unix socket to communicate with a locally-running PostgreSQL server, otherwise it should be set to the hosname or IP address of the PostgreSQL server to be used
+- `project_db_admin_user`: PostgreSQL user with Superuser privileges that may be used to create the application roles on a remote PostgreSQL server
+- `project_db_admin_password`: PostgreSQL password of above-mentioned `project_db_admin_user`

--- a/ansible/roles/sufia/tasks/postgres_setup.yml
+++ b/ansible/roles/sufia/tasks/postgres_setup.yml
@@ -1,12 +1,34 @@
 ---
-- name: create project database role
+- name: create project database role on local postgresql server
   postgresql_user:
     name: '{{ project_db_user }}'
     password: '{{ project_db_password }}'
     role_attr_flags: CREATEDB
+  when: postgresql_is_local
 
-- name: create project database
+- name: create project database role on remote postgresql server
+  postgresql_user:
+    name: '{{ project_db_user }}'
+    password: '{{ project_db_password }}'
+    role_attr_flags: CREATEDB
+    login_user: '{{ project_db_admin_user }}'
+    login_password: '{{ project_db_admin_password }}'
+    login_host: '{{ project_db_host }}'
+  when: postgresql_is_local | bool == False
+
+- name: create project database on local postgresql server
   postgresql_db:
     name: '{{ project_db_name }}'
     encoding: 'UTF-8'
     owner: '{{ project_db_user }}'
+  when: postgresql_is_local
+
+- name: create project database on remote postgresql server
+  postgresql_db:
+    name: '{{ project_db_name }}'
+    encoding: 'UTF-8'
+    owner: '{{ project_db_user }}'
+    login_user: '{{ project_db_admin_user }}'
+    login_password: '{{ project_db_admin_password }}'
+    login_host: '{{ project_db_host }}'
+  when: postgresql_is_local | bool == False

--- a/ansible/roles/sufia/templates/secrets.yml.j2
+++ b/ansible/roles/sufia/templates/secrets.yml.j2
@@ -10,13 +10,7 @@ default: &default
     name: {{ project_db_name }}
     username: {{ project_db_user }}
     password: {{ project_db_password }}
-    # The host: and port: below are optional.  Do not use them unless you want
-    # to connect to a database over TCP/IP, e.g., one running on a different
-    # server.  If host: and port: are undefined, connection will be assumed to
-    # be local, e.g., via a Unix domain socket.  The port: setting will default
-    # to the correct one for the database adapter, and so should only be
-    # uncommented if the database is running on a non-standard port.
-    #host: example.com  # Hostname of database server
+    host: {{ project_db_host }}
     #port: 5432         # TCP/IP port of database server
   ezid: &ezid
     default_shoulder: {{ project_ezid_shoulder }}


### PR DESCRIPTION
The original BASH scripts supported the use of a local or remote
PostgreSQL server for the Rails ActiveRecord DB.  The Ansible version
was a regression in that it supported only the use of a local
PostgreSQL server.  This commit eliminates this regression and allows
either a local or a remote PostgreSQL server to be used.

If {{project_db_host}} points either to "localhost" or a directory (in
which the PostgreSQL Unix socket resides) then it is assumed a local
PostgreSQL server is to be used.  In this case a local server is
installed and set up.  Otherwise, it is assumed a remote PostgreSQL
server (already installed) is to be used, in which case only necessary
PostgreSQL client libraries are installed.