### PR TITLE
Provides more descriptive vm name for Virtualbox

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -84,6 +84,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     hydravm.vm.hostname = "hydravm"
 
     hydravm.vm.provider :virtualbox do |vb, override|
+      vb.name = $secrets_items["vm_name"] if !$secrets_items["vm_name"].nil? && !$secrets_items["vm_name"].empty?
+      vb.customize ["modifyvm", :id, "--description", "Created from Vagrantfile in #{Dir.pwd}"]
       override.vm.box = "ubuntu/trusty64"
       vb.memory = 4096
       vb.cpus = 2

--- a/ansible/example_site_secrets.yml
+++ b/ansible/example_site_secrets.yml
@@ -1,6 +1,8 @@
 ---
 # Commonly Changed Variables:
 #
+# VM Name
+# vm_name: 'testing'
 # Name of project application
 project_name: 'data-repo'
 # The project branch of the application to be used


### PR DESCRIPTION
Allows user to specify vm name for Virtualbox and falls back to "project_name" if not defined. Useful for me so that I can identify my vm's in the Virtualbox gui.
Currently, all vm's are named similarly.
<img width="798" alt="before" src="https://cloud.githubusercontent.com/assets/1202435/23094417/8e56a12a-f5c6-11e6-900a-4b30574376ce.png">
This change allows them to be more descriptive
<img width="785" alt="after" src="https://cloud.githubusercontent.com/assets/1202435/23094425/a0f698f8-f5c6-11e6-8bc7-b55052e6894e.png">

