### PR TITLE
Fix cron job timing specification

### DIFF
--- a/ansible/roles/geoblacklight/tasks/cron.yml
+++ b/ansible/roles/geoblacklight/tasks/cron.yml
@@ -3,10 +3,11 @@
   cron:
     user: "{{ project_runner }}"
     hour: 0
+    minute: 0
     cron_file: geoblacklight_ingest
     job: >
       cd "{{ project_app_root }}" &&
       RAILS_ENV={{ project_app_env }}
-      /usr/local/bin/bundle exec rake vtul:geoblacklight:data_ingest
+      /usr/local/bin/bundle exec rake vtul:geoblacklight:data_ingest > /dev/null 2>&1
     name: GeoBlacklight Ingest
     state: present


### PR DESCRIPTION
The cron job to process SFTP uploads is supposed to run once a day at
midnight. The current time specification to cron is incorrect and
causes the job to run every minute between midnight and 1 am.  This
change fixes that.

Also, we silence the output of the cron job as the rake task logs
everything to files under the SFTP "Reports" directories.  This avoids
harmless warnings being mailed by cron each day.