### PR TITLE
add zip package from apt

### DIFF
--- a/ansible/roles/sufia/tasks/main.yml
+++ b/ansible/roles/sufia/tasks/main.yml
@@ -7,6 +7,7 @@
     update_cache: yes
   with_items:
     - git
+    - zip
     - unzip
     - imagemagick
     - libreoffice


### PR DESCRIPTION
I'm working on a feature for VTechData which would let users download all items in a dataset in a zip file. I tried using the rubyzip gem but it modifies the files in some way that affects the checksums, which is not desirable.