### PR TITLE
Make explicit the "graylog_enable" setting

### DIFF
--- a/ansible/example_site_secrets.yml
+++ b/ansible/example_site_secrets.yml
@@ -29,9 +29,13 @@ project_runner_group: '{{ project_runner }}'
 
 # Graylog logging
 #
-# If the project_app_env is "production" then you may want to enable Graylog
-# logging.  Here are applicable settings:
+# If the project_app_env is "production" then Graylog logging will be enabled by
+# default.  Below are applicable settings:
 #
+# Graylog logging defaults to true for the RAILS_ENV "production" environment.
+# Uncomment the setting below to disable Graylog explicitly and use the standard
+# Rails logger instead.
+#graylog_enable: false
 # Host running Graylog server
 graylog_host: 127.0.0.1
 # Port on which Graylog server is listening


### PR DESCRIPTION
The code to toggle on or off logging to Graylog is governed by the "graylog_enable" setting in the Ansible playbooks.  Although this is set by default in the appropriate roles, it has always been possible to override the default setting by setting "graylog_enable" explicitly in "site_secrets.yml".  This change documents that ability explicitly in "example_site_secrets.yml".