### PR TITLE
Support sidekiq as an Active Job backend

### DIFF
--- a/ansible/roles/sufia/defaults/main.yml
+++ b/ansible/roles/sufia/defaults/main.yml
@@ -20,3 +20,6 @@ graylog_protocol: udp
 graylog_network_locality: WAN
 graylog_facility: "{{ project_name }}"
 graylog_verbosity: "info"
+# Active Job backend choice
+active_job_backend: "{{ 'sidekiq' if project_name == 'iawa' else 'resque' }}"
+sidekiq_workers: 1

--- a/ansible/roles/sufia/handlers/main.yml
+++ b/ansible/roles/sufia/handlers/main.yml
@@ -15,3 +15,9 @@
     name: resque-pool
     state: restarted
   become: yes
+
+- name: restart sidekiq workers
+  service:
+    name: workers
+    state: restarted
+  become: yes

--- a/ansible/roles/sufia/tasks/main.yml
+++ b/ansible/roles/sufia/tasks/main.yml
@@ -1,4 +1,11 @@
 ---
+- name: make sure active_job_backend setting is valid
+  fail:
+    msg: 'active_job_backend ({{ active_job_backend }}) needs to be either sidekiq or resque.'
+  when:
+    - active_job_backend != 'sidekiq'
+    - active_job_backend != 'resque'
+
 - name: install apt dependencies
   apt:
     name: '{{ item }}'
@@ -152,14 +159,27 @@
   become: yes
   become_user: '{{ project_owner }}'
 
-- name: check if resque-pool is installed
-  stat:
-    path: '{{ project_app_root}}/bin/resque-pool'
-  register: resque_installed
+- block:
+  - name: check if resque-pool is installed
+    stat:
+      path: '{{ project_app_root}}/bin/resque-pool'
+    register: resque_installed
 
-- name: install resque-pool service
-  include: tasks/resque.yml
-  when: resque_installed.stat.exists
+  - name: install resque-pool service
+    include: tasks/resque.yml
+    when: resque_installed.stat.exists
+  when: active_job_backend == 'resque'
+
+- block:
+  - name: check if sidekiq is installed
+    stat:
+      path: '{{ project_app_root}}/bin/sidekiq'
+    register: sidekiq_installed
+
+  - name: install sidekiq services
+    include: tasks/sidekiq.yml
+    when: sidekiq_installed.stat.exists
+  when: active_job_backend == 'sidekiq'
 
 - name: ensure the Noid minter statefile dir exists
   file:

--- a/ansible/roles/sufia/tasks/sidekiq.yml
+++ b/ansible/roles/sufia/tasks/sidekiq.yml
@@ -1,0 +1,18 @@
+- name: copy sidekiq init scripts
+  template:
+    src: "{{ item.file }}"
+    dest: "{{ item.dest }}"
+    mode: 0755
+  with_items:
+    - file: workers.conf.j2
+      dest: /etc/init/workers.conf
+    - file: sidekiq.conf.j2
+      dest: /etc/init/sidekiq.conf
+  notify:
+    - restart redis
+    - restart sidekiq workers
+
+- name: ensure sidekiq runs at startup
+  service:
+    name: workers
+    enabled: yes

--- a/ansible/roles/sufia/templates/secrets.yml.j2
+++ b/ansible/roles/sufia/templates/secrets.yml.j2
@@ -43,6 +43,8 @@ default: &default
   # The google_analytics_id: below should only be defined if usage statistics
   # are to be gathered.  Leave commented otherwise.
   #google_analytics_id: UA-99999999-1                     # Google Analytics tracking ID
+  # The Active Job background task handler
+  active_job_backend: :{{ active_job_backend }}
   # secret_key_base is typically set to a long, random string, such as the output
   # of "openssl rand -hex 64" (or the output of the "rails secret" task).
   secret_key_base: abad1dea

--- a/ansible/roles/sufia/templates/sidekiq.conf.j2
+++ b/ansible/roles/sufia/templates/sidekiq.conf.j2
@@ -1,0 +1,71 @@
+# /etc/init/sidekiq.conf - Sidekiq config
+
+# This example config should work with Ubuntu 12.04+.  It
+# allows you to manage multiple Sidekiq instances with
+# Upstart, Ubuntu's native service management tool.
+#
+# See workers.conf for how to manage all Sidekiq instances at once.
+#
+# Save this config as /etc/init/sidekiq.conf then manage sidekiq with:
+#   sudo start sidekiq index=0
+#   sudo stop sidekiq index=0
+#   sudo status sidekiq index=0
+#
+# Hack Upstart's reload command to 'quiet' Sidekiq:
+#
+#   sudo reload sidekiq index=0
+#
+# or use the service command:
+#   sudo service sidekiq {start,stop,restart,status}
+#
+
+description "Sidekiq Background Worker"
+
+# This script is not meant to start on bootup, workers.conf
+# will start all sidekiq instances explicitly when it starts.
+#start on runlevel [2345]
+#stop on runlevel [06]
+
+# change to match your deployment user
+setuid {{ project_runner }}
+setgid {{ project_runner_group }}
+env HOME={{ project_owner_home }}
+
+respawn
+respawn limit 3 30
+
+# TERM is sent by sidekiqctl when stopping sidekiq. Without declaring these as
+# normal exit codes, it just respawns.
+normal exit 0 TERM
+
+# Older versions of Upstart might not support the reload command and need
+# this commented out.
+reload signal TSTP
+
+# Upstart waits 5 seconds by default to kill the a process. Increase timeout to
+# give sidekiq process enough time to exit.
+kill timeout 15
+
+instance $index
+
+script
+# this script runs in /bin/sh by default
+# respawn as bash so we can source in rbenv
+exec /bin/bash <<'EOT'
+  # Pick your poison :) Or none if you're using a system wide installed Ruby.
+  # rbenv
+  # source /home/apps/.bash_profile
+  # OR
+  # source /home/apps/.profile
+  # OR system:
+  # source /etc/profile.d/rbenv.sh
+  #
+  # rvm
+  # source /home/apps/.rvm/scripts/rvm
+
+  # Logs out to /var/log/upstart/sidekiq.log by default
+
+  cd {{ project_app_root }}
+  exec bundle exec sidekiq -i ${index} -e {{ project_app_env }}
+EOT
+end script

--- a/ansible/roles/sufia/templates/workers.conf.j2
+++ b/ansible/roles/sufia/templates/workers.conf.j2
@@ -1,0 +1,37 @@
+# /etc/init/workers.conf - manage a set of Sidekiqs
+
+# This example config should work with Ubuntu 12.04+.  It
+# allows you to manage multiple Sidekiq instances with
+# Upstart, Ubuntu's native service management tool.
+#
+# See sidekiq.conf for how to manage a single Sidekiq instance.
+#
+# Use "stop workers" to stop all Sidekiq instances.
+# Use "start workers" to start all instances.
+# Use "restart workers" to restart all instances.
+# Crazy, right?
+#
+
+description "manages the set of sidekiq processes"
+
+# This starts upon bootup and stops on shutdown
+start on runlevel [2345]
+stop on runlevel [06]
+
+# Set this to the number of Sidekiq processes you want
+# to run on this machine
+env NUM_WORKERS={{ sidekiq_workers }}
+
+pre-start script
+  for i in `seq 1 ${NUM_WORKERS}`
+  do
+    start sidekiq index=$i
+  done
+end script
+
+post-stop script
+  for i in `seq 1 ${NUM_WORKERS}`
+  do
+    stop sidekiq index=$i
+  done
+end script


### PR DESCRIPTION
Add support for choosing which Active Job backend to use: resque or sidekiq. The variable "active_job_backend" designates which backend to use. Currently, it must be set either to the string "resque" or "sidekiq". It defaults to "sidekiq" currently for the "iawa" project, otherwise it defaults to "resque".

For the "sidekiq" backend, the variable "sidekiq_workers" controls the number of sidekiq processes to spawn to handle backend task processing. It defaults to 1. For large amounts of concurrent background processing, this should be increased. Each sidekiq process typically controls 25 background processing threads.