### PR TITLE
Make sure Fedora 4 and Solr are running before rake tasks run

### DIFF
--- a/ansible/roles/fedora4/tasks/main.yml
+++ b/ansible/roles/fedora4/tasks/main.yml
@@ -3,7 +3,6 @@
   service:
     name: tomcat7
     state: stopped
-  notify: restart tomcat
 
 - name: add the fedora group
   group:
@@ -37,4 +36,8 @@
     line: JAVA_OPTS='-Dfcrepo.home={{ fedora_data_dir }} -Djava.awt.headless=true -Dfile.encoding=UTF-8 -server {{ fedora_java_vm_opts }}'
     regexp: "^JAVA_OPTS=.*"
     state: present
-  notify: restart tomcat
+
+- name: start tomcat
+  service:
+    name: tomcat7
+    state: started

--- a/ansible/roles/solr/tasks/main.yml
+++ b/ansible/roles/solr/tasks/main.yml
@@ -34,7 +34,8 @@
     - path: '{{ solr_data_dir }}/dist'
       source: '{{ solr_install_dir }}/solr/dist'
 
-- name: ensure solr starts on boot
+- name: ensure solr starts on boot and is started
   service:
     name: solr
     enabled: yes
+    state: started

--- a/ansible/roles/sufia/tasks/iawa.yml
+++ b/ansible/roles/sufia/tasks/iawa.yml
@@ -1,18 +1,25 @@
 ---
 - block:
-  # - name: load workflow
-  #   command: bundle exec rails hyrax:workflow:load
-  #   args:
-  #     chdir: '{{ project_app_root }}'
-  # - name: create default admin set
-  #   command: bundle exec rails hyrax:default_admin_set:create
-  #   args:
-  #     chdir: '{{ project_app_root }}'
+  - name: load workflow
+    command: bundle exec rails hyrax:workflow:load
+    args:
+      chdir: '{{ project_app_root }}'
+
+  - name: create default admin set
+    command: bundle exec rails hyrax:default_admin_set:create
+    args:
+      chdir: '{{ project_app_root }}'
+
   - name: create roles
     command: bundle exec rails iawa:add_roles
     args:
       chdir: '{{ project_app_root }}'
+  become: yes
+  become_user: '{{ project_runner }}'
+  environment:
+    RAILS_ENV: '{{ project_app_env }}'
 
+- block:
   - name: copy list of users
     copy:
       src: "{{ local_files_dir }}/user_list.txt"
@@ -32,7 +39,12 @@
       dest: '{{ project_app_root }}/admin_list.txt'
     ignore_errors: False
     register: copy_admin_list
+  become: yes
+  become_user: '{{ project_owner }}'
+  environment:
+    RAILS_ENV: '{{ project_app_env }}'
 
+- block:
   - name: upgrade users
     command: bundle exec rails iawa:upgrade_users
     args:
@@ -43,8 +55,7 @@
     command: bundle exec rails iawa:add_controlled_vocabs
     args:
       chdir: '{{ project_app_root }}'
-
   become: yes
-  become_user: '{{ project_owner }}'
+  become_user: '{{ project_runner }}'
   environment:
     RAILS_ENV: '{{ project_app_env }}'

--- a/ansible/roles/sufia/tasks/main.yml
+++ b/ansible/roles/sufia/tasks/main.yml
@@ -90,19 +90,19 @@
     state: directory
   with_items:
     - path: "{{ project_app_root }}/tmp"
-      mode: "0777"
+      mode: "u=rwX,g=rwXs,o="
     - path: "{{ project_app_root }}/tmp/pids"
-      mode: "0777"
+      mode: "u=rwX,g=rwXs,o="
     - path: "{{ project_app_root }}/tmp/derivatives"
-      mode: "0777"
+      mode: "u=rwX,g=rwXs,o="
     - path: "{{ project_app_root }}/tmp/uploads"
-      mode: "0777"
+      mode: "u=rwX,g=rwXs,o="
     - path: "{{ project_app_root }}/tmp/cache/assets/sprockets/v3.0"
-      mode: "0777"
+      mode: "u=rwX,g=rwXs,o="
     - path: "{{ project_app_root }}/log"
-      mode: "0770"
+      mode: "u=rwX,g=rwXs,o="
     - path: "{{ project_app_root }}/db"
-      mode: "0770"
+      mode: "u=rwX,g=rwXs,o="
 
 - name: ensure log files have the correct ownerships and permissions
   file:
@@ -195,6 +195,10 @@
   delegate_to: 127.0.0.1
   register: project_tasks
   become: no
+
+- name: execute pending handlers for rake tasks to work
+  meta: flush_handlers
+  when: project_tasks.stat.exists
 
 - block:
   - name: create db if necessary


### PR DESCRIPTION
Modified the "fedora4" role so that it starts Tomcat again at the end of its tasks having stopped it at the beginning of them. Also, modified the "solr" role to have the service in a running state at the end of its tasks (this was not explicit before). Finally, had Ansible flush all handlers if there are any project-local tasks to be run in the "sufia" role. This ensures that any Solr cores, etc., defined earlier are reflected in the running services (which are restarted by the handlers to do so). That way, any rake tasks that rely on functioning Fedora 4 and Solr services will work.

Because of the above, various rake tasks that were previously commented out (because they failed during the Ansible provisioning) have now been uncommented (at least in the case of "iawa"). This resulted in bringing some permissions problems to light due to the way the project-local tasks were run. Making the project-local tasks be more granular in which user was used for each task solved the permissions problem.