### PR TITLE
Make it easier to switch between Java roles

### DIFF
--- a/ansible/roles/common/defaults/main.yml
+++ b/ansible/roles/common/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+java_vendor: openjdk

--- a/ansible/roles/solr/meta/main.yml
+++ b/ansible/roles/solr/meta/main.yml
@@ -1,3 +1,5 @@
 ---
 dependencies:
-  - { role: java8 }
+  - { role: common }
+  - { role: java8, when: java_vendor == 'oracle' }
+  - { role: openjdk8, when: java_vendor == 'openjdk' }

--- a/ansible/roles/tomcat7/meta/main.yml
+++ b/ansible/roles/tomcat7/meta/main.yml
@@ -1,4 +1,5 @@
 ---
 dependencies:
   - { role: common }
-  - { role: java8 }
+  - { role: java8, when: java_vendor == 'oracle' }
+  - { role: openjdk8, when: java_vendor == 'openjdk' }

--- a/ansible/roles/tomcat7/tasks/main.yml
+++ b/ansible/roles/tomcat7/tasks/main.yml
@@ -15,10 +15,10 @@
     dest: /etc/tomcat7/server.xml
     mode: 0644
 
-- name: add line to use openjdk-8
+- name: add line to specify java_home
   lineinfile:
     dest: /etc/default/tomcat7
-    line: "JAVA_HOME=/usr/lib/jvm/java-8-oracle"
+    line: "JAVA_HOME=/usr/lib/jvm/java-8-{{'openjdk-amd64' if java_vendor == 'openjdk' else 'oracle'}}"
 
 - name: ensure tomcat7 starts on boot
   service:


### PR DESCRIPTION
Currently, selecting whether to use the "java8" (Oracle) or "openjdk8" (OpenJDK) roles involves changing some code in the roles that use Java. This change makes the choice of Java role more easily selectable via the variable "java_vendor". If "java_vendor" is set to "oracle" then the "java8" role is used. If it is set to "openjdk" then the "openjdk8" role is used.

The default for "java_vendor" is currently "openjdk".