### PR TITLE
Ensure "assets:precompile" is done in the correct place

### DIFF
--- a/ansible/roles/hyrax/tasks/main.yml
+++ b/ansible/roles/hyrax/tasks/main.yml
@@ -196,10 +196,6 @@
   register: project_tasks
   become: no
 
-- name: execute pending handlers for rake tasks to work
-  meta: flush_handlers
-  when: project_tasks.stat.exists
-
 - block:
   - name: create db if necessary
     command: ./bin/rake db:create
@@ -212,11 +208,6 @@
     args:
       chdir: '{{ project_app_root }}'
     when: clone_app.changed or deploy_app.changed
-
-  - name: include project specific tasks
-    include: tasks/{{ project_name }}.yml
-    when: project_tasks.stat.exists
-
   become: yes
   become_user: '{{ project_runner }}'
   environment:
@@ -233,3 +224,16 @@
   when: project_app_env == 'production'
   notify:
     - precompile assets
+
+- name: execute pending handlers for rake tasks to work
+  meta: flush_handlers
+  when: project_tasks.stat.exists
+
+- block:
+  - name: include project specific tasks
+    include: tasks/{{ project_name }}.yml
+    when: project_tasks.stat.exists
+  become: yes
+  become_user: '{{ project_runner }}'
+  environment:
+    RAILS_ENV: '{{ project_app_env }}'

--- a/ansible/roles/sufia/tasks/main.yml
+++ b/ansible/roles/sufia/tasks/main.yml
@@ -172,20 +172,12 @@
   register: project_tasks
   become: no
 
-- name: execute pending handlers for rake tasks to work
-  meta: flush_handlers
-  when: project_tasks.stat.exists
-
 - block:
   - name: migrate db
     command: bundle exec rake db:migrate
     args:
       chdir: '{{ project_app_root }}'
     when: clone_app.changed or deploy_app.changed
-
-  - name: include project specific tasks
-    include: tasks/{{ project_name }}.yml
-    when: project_tasks.stat.exists
 
   - name: add rails bin shims for development
     command: bundle exec rake rails:update:bin
@@ -202,7 +194,6 @@
     when: project_app_env == 'development'
     environment:
       RAILS_ENV: 'test'
-
   become: yes
   become_user: '{{ project_runner }}'
   environment:
@@ -219,3 +210,16 @@
   when: project_app_env == 'production'
   notify:
     - precompile assets
+
+- name: execute pending handlers for rake tasks to work
+  meta: flush_handlers
+  when: project_tasks.stat.exists
+
+- block:
+  - name: include project specific tasks
+    include: tasks/{{ project_name }}.yml
+    when: project_tasks.stat.exists
+  become: yes
+  become_user: '{{ project_runner }}'
+  environment:
+    RAILS_ENV: '{{ project_app_env }}'


### PR DESCRIPTION
Currently, the "assets:precompile" Rake task that is done for RAILS_ENV=production mode is done right at the very end of the deployment process.  Unfortunately, any application-specific Rake tasks that utilise the asset pipeline will fail in RAILS_ENV=production mode (at the very least on a fresh install) because these assets are not in place due to the tasks being run before the "assets:precompile" task is reached.

This change makes the application-specific Rake/provisioning tasks run at the end of provisioning.