### PR TITLE
Enable support for Google Analytics ID

### DIFF
--- a/ansible/example_site_secrets.yml
+++ b/ansible/example_site_secrets.yml
@@ -65,6 +65,8 @@ project_orcid_app_id: '0000-0000-0000-0000'
 project_orcid_app_secret: 'XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX'
 # Which ORCID service to use: sandbox or production
 project_orcid_service: 'sandbox'
+# Google Analytics ID
+#project_google_analytics_id: UA-99999999-1
 # Application database name for Rails config/database.yml "database:" setting
 project_db_name: 'datarepo'
 # Application database user for Rails config/database.yml "username:" setting

--- a/ansible/roles/hyrax/README.md
+++ b/ansible/roles/hyrax/README.md
@@ -26,6 +26,7 @@ Role variables are listed below, along with their defaults:
     project_deploy_key: ''
     project_app_root: '{{ project_owner_home }}/{{ project_name }}'
     project_solr_test_core: test
+    project_google_analytics_id: UA-99999999-1 (commented out)
 
 This role makes use of the `local_files_dir` variable defined in the top-level `site_vars.yml` file. The `local_files_dir` setting points to a local directory on the provisioning host where locally-provided files may be supplied to the deployment and provisioning process. In the case of the `hyrax` role, this directory is used to supply the `user_list.txt`, `admin_list.txt`, and `images.zip` carousel images for the `data-repo` application.
 
@@ -37,3 +38,4 @@ The Hyrax role also uses several variables that are normally defined in `site_se
 - `project_db_host`: host of PostgreSQL server, used as application host name for Rails config/database.yml `host:` setting. This should be set to `/var/run/postgresql` to use a Unix socket to communicate with a locally-running PostgreSQL server, otherwise it should be set to the hosname or IP address of the PostgreSQL server to be used
 - `project_db_admin_user`: PostgreSQL user with Superuser privileges that may be used to create the application roles on a remote PostgreSQL server
 - `project_db_admin_password`: PostgreSQL password of above-mentioned `project_db_admin_user`
+- `project_google_analytics_id`: the Google Analytics ID associated with this project

--- a/ansible/roles/hyrax/defaults/main.yml
+++ b/ansible/roles/hyrax/defaults/main.yml
@@ -23,3 +23,5 @@ graylog_verbosity: "info"
 # Active Job backend choice
 active_job_backend: "{{ 'sidekiq' if project_name == 'iawa' else 'resque' }}"
 sidekiq_workers: 1
+# Google Analytics
+hyrax_google_analytics_comment_marker: "{{ '' if project_google_analytics_id is defined else '#' }}"

--- a/ansible/roles/hyrax/templates/secrets.yml.j2
+++ b/ansible/roles/hyrax/templates/secrets.yml.j2
@@ -42,7 +42,7 @@ default: &default
   cas_endpoint_url: {{ project_cas_url }}
   # The google_analytics_id: below should only be defined if usage statistics
   # are to be gathered.  Leave commented otherwise.
-  #google_analytics_id: UA-99999999-1                     # Google Analytics tracking ID
+  {{hyrax_google_analytics_comment_marker}}google_analytics_id: "{{ project_google_analytics_id|default('') }}"                     # Google Analytics tracking ID
   # The Active Job background task handler
   active_job_backend: :{{ active_job_backend }}
   # secret_key_base is typically set to a long, random string, such as the output

--- a/ansible/roles/sufia/README.md
+++ b/ansible/roles/sufia/README.md
@@ -26,6 +26,7 @@ Role variables are listed below, along with their defaults:
     project_deploy_key: ''
     project_app_root: '{{ project_owner_home }}/{{ project_name }}'
     project_solr_test_core: test
+    project_google_analytics_id: UA-99999999-1 (commented out)
 
 This role makes use of the `local_files_dir` variable defined in the top-level `site_vars.yml` file. The `local_files_dir` setting points to a local directory on the provisioning host where locally-provided files may be supplied to the deployment and provisioning process. In the case of the `sufia` role, this directory is used to supply the `user_list.txt`, `admin_list.txt`, and `images.zip` carousel images for the `data-repo` application.
 
@@ -37,3 +38,4 @@ The Sufia role also uses several variables that are normally defined in `site_se
 - `project_db_host`: host of PostgreSQL server, used as application host name for Rails config/database.yml `host:` setting. This should be set to `/var/run/postgresql` to use a Unix socket to communicate with a locally-running PostgreSQL server, otherwise it should be set to the hosname or IP address of the PostgreSQL server to be used
 - `project_db_admin_user`: PostgreSQL user with Superuser privileges that may be used to create the application roles on a remote PostgreSQL server
 - `project_db_admin_password`: PostgreSQL password of above-mentioned `project_db_admin_user`
+- `project_google_analytics_id`: the Google Analytics ID associated with this project

--- a/ansible/roles/sufia/defaults/main.yml
+++ b/ansible/roles/sufia/defaults/main.yml
@@ -20,3 +20,5 @@ graylog_protocol: udp
 graylog_network_locality: WAN
 graylog_facility: "{{ project_name }}"
 graylog_verbosity: "info"
+# Google Analytics
+sufia_google_analytics_comment_marker: "{{ '' if project_google_analytics_id is defined else '#' }}"

--- a/ansible/roles/sufia/templates/secrets.yml.j2
+++ b/ansible/roles/sufia/templates/secrets.yml.j2
@@ -42,7 +42,7 @@ default: &default
   cas_endpoint_url: {{ project_cas_url }}
   # The google_analytics_id: below should only be defined if usage statistics
   # are to be gathered.  Leave commented otherwise.
-  #google_analytics_id: UA-99999999-1                     # Google Analytics tracking ID
+  {{sufia_google_analytics_comment_marker}}google_analytics_id: "{{ project_google_analytics_id|default('') }}"                     # Google Analytics tracking ID
   # secret_key_base is typically set to a long, random string, such as the output
   # of "openssl rand -hex 64" (or the output of the "rake secret" task).
   secret_key_base: abad1dea


### PR DESCRIPTION
This change restores the ability to supply a Google Analytics ID to a Sufia or Hyrax application.

The Google Analytics ID for the application is defined in "site_secrets.yml" via the "project_google_analytics_id" variable. The "project_google_analytics_id" variable should be commented out if the application is not to enable Google Analytics.