### PR TITLE
assets need to be in place before precompile

### DIFF
--- a/ansible/roles/sufia/handlers/main.yml
+++ b/ansible/roles/sufia/handlers/main.yml
@@ -1,19 +1,21 @@
 ---
-- name: precompile assets
-  command: bundle exec rake assets:precompile
+- name: clear rails cache
+  command: bundle exec rake tmp:cache:clear
   args:
     chdir: '{{ project_app_root }}'
-  when: project_app_env == 'production'
-  notify: restart nginx
+  notify:
+    - precompile assets
+    - restart nginx
   become: yes
   become_user: '{{ project_owner }}'
   environment:
     RAILS_ENV: '{{ project_app_env }}'
 
-- name: clear rails cache
-  command: bundle exec rake tmp:cache:clear
+- name: precompile assets
+  command: bundle exec rake assets:precompile
   args:
     chdir: '{{ project_app_root }}'
+  when: project_app_env == 'production'
   notify: restart nginx
   become: yes
   become_user: '{{ project_owner }}'


### PR DESCRIPTION
When running in production precompile seems to be running before the carousel images and fonts are copied into place resulting in multiple 404's. You can see the order in the vagrant/ansible output here: https://gist.github.com/whunter/35058f7bced3ca660028f6e7e0d108bd

We need the images and fonts to be in place before precompile is run like this:
https://gist.github.com/whunter/bc2664b1d138cc77e485ddf6d32810af
