### PR TITLE
Use "rails" instead of "rake"

### DIFF
--- a/ansible/roles/hyrax/tasks/main.yml
+++ b/ansible/roles/hyrax/tasks/main.yml
@@ -198,13 +198,13 @@
 
 - block:
   - name: create db if necessary
-    command: ./bin/rake db:create
+    command: bundle exec rails db:create
     args:
       chdir: '{{ project_app_root }}'
     when: clone_app.changed or deploy_app.changed
 
   - name: migrate the database
-    command: ./bin/rake db:migrate
+    command: bundle exec rails db:migrate
     args:
       chdir: '{{ project_app_root }}'
     when: clone_app.changed or deploy_app.changed


### PR DESCRIPTION
Hyrax is a Rails 5+ application, and Rails 5 deprecates the use of "rake" in favour of using the "rails" command to run Rake tasks.

This change honours the Rails 5 convention of using "rails" to run Rake tasks.  It also changes to use "bundle exec" to do PATH resolution.