### PR TITLE
Refine "hyrax" role actions

### DIFF
--- a/ansible/roles/hyrax/handlers/main.yml
+++ b/ansible/roles/hyrax/handlers/main.yml
@@ -10,9 +10,9 @@
   become_user: '{{ project_owner }}'
   environment:
     RAILS_ENV: '{{ project_app_env }}'
-    
+
 - name: precompile assets
-  command: ./bin/rails assets:precompile
+  command: bundle exec rails assets:precompile
   args:
     chdir: '{{ project_app_root }}'
   when: project_app_env == 'production'

--- a/ansible/roles/hyrax/tasks/iawa.yml
+++ b/ansible/roles/hyrax/tasks/iawa.yml
@@ -1,15 +1,5 @@
 ---
 - block:
-  - name: load workflow
-    command: bundle exec rails hyrax:workflow:load
-    args:
-      chdir: '{{ project_app_root }}'
-
-  - name: create default admin set
-    command: bundle exec rails hyrax:default_admin_set:create
-    args:
-      chdir: '{{ project_app_root }}'
-
   - name: create roles
     command: bundle exec rails iawa:add_roles
     args:

--- a/ansible/roles/hyrax/tasks/main.yml
+++ b/ansible/roles/hyrax/tasks/main.yml
@@ -214,7 +214,7 @@
     RAILS_ENV: '{{ project_app_env }}'
 
 - name: remove old precompiled assets
-  command: ./bin/rails assets:clobber
+  command: bundle exec rails assets:clobber
   args:
     chdir: '{{ project_app_root }}'
   become: yes
@@ -227,9 +227,18 @@
 
 - name: execute pending handlers for rake tasks to work
   meta: flush_handlers
-  when: project_tasks.stat.exists
 
 - block:
+  - name: load workflow
+    command: bundle exec rails hyrax:workflow:load
+    args:
+      chdir: '{{ project_app_root }}'
+
+  - name: create default admin set
+    command: bundle exec rails hyrax:default_admin_set:create
+    args:
+      chdir: '{{ project_app_root }}'
+
   - name: include project specific tasks
     include: tasks/{{ project_name }}.yml
     when: project_tasks.stat.exists


### PR DESCRIPTION
Some Rake tasks that are properly part of every Hyrax application setup (e.g., "hyrax:workflow:load" and "hyrax:default_admin_set:create") were done as part of the IAWA project-specific tasks.  To support more Hyrax projects, this change moves those generic Hyrax Rake tasks out of there into the "hyrax" main role itself, where it belongs.

This change also does some minor cleanup, replacing direct path invocation of "rails" commands with "bundle exec" invocation to make it uniform within the "hyrax" role.