### PR TITLE
make public/uploads and public/system writable 

### DIFF
--- a/ansible/roles/hyrax/tasks/main.yml
+++ b/ansible/roles/hyrax/tasks/main.yml
@@ -103,6 +103,10 @@
       mode: "u=rwX,g=rwXs,o="
     - path: "{{ project_app_root }}/db"
       mode: "u=rwX,g=rwXs,o="
+    - path: "{{ project_app_root }}/public/uploads"
+      mode: "u=rwX,g=rwXs,o="
+    - path: "{{ project_app_root }}/public/system"
+      mode: "u=rwX,g=rwXs,o="
 
 - name: ensure log files have the correct ownerships and permissions
   file:


### PR DESCRIPTION
...for user profile img uploads. These can't go in tmp as they need to persist. Ultimately I'd rather store them elsewhere (AWS) but that might be a bit down the road.