### PR TITLE
Allow Riiif cache duration to be passed via config/secrets.yml

### DIFF
--- a/ansible/roles/hyrax/README.md
+++ b/ansible/roles/hyrax/README.md
@@ -27,6 +27,7 @@ Role variables are listed below, along with their defaults:
     project_app_root: '{{ project_owner_home }}/{{ project_name }}'
     project_solr_test_core: test
     project_google_analytics_id: UA-99999999-1 (commented out)
+    iiif_cache_duration: 30 days (in seconds) for project_app_env "production" mode, else 5 days (in seconds)
 
 This role makes use of the `local_files_dir` variable defined in the top-level `site_vars.yml` file. The `local_files_dir` setting points to a local directory on the provisioning host where locally-provided files may be supplied to the deployment and provisioning process. In the case of the `hyrax` role, this directory is used to supply the `user_list.txt`, `admin_list.txt`, and `images.zip` carousel images for the `data-repo` application.
 
@@ -39,3 +40,4 @@ The Hyrax role also uses several variables that are normally defined in `site_se
 - `project_db_admin_user`: PostgreSQL user with Superuser privileges that may be used to create the application roles on a remote PostgreSQL server
 - `project_db_admin_password`: PostgreSQL password of above-mentioned `project_db_admin_user`
 - `project_google_analytics_id`: the Google Analytics ID associated with this project
+- `iiif_cache_duration`: the amount of time in seconds an object will be cached by the IIIF server

--- a/ansible/roles/hyrax/defaults/main.yml
+++ b/ansible/roles/hyrax/defaults/main.yml
@@ -25,3 +25,5 @@ active_job_backend: "{{ 'sidekiq' if project_name == 'iawa' else 'resque' }}"
 sidekiq_workers: 1
 # Google Analytics
 hyrax_google_analytics_comment_marker: "{{ '' if project_google_analytics_id is defined else '#' }}"
+# Riiif cache cache_duration in seconds
+iiif_cache_duration: "{{ '2592000' if project_app_env == 'production' else '432000' }}"

--- a/ansible/roles/hyrax/templates/secrets.yml.j2
+++ b/ansible/roles/hyrax/templates/secrets.yml.j2
@@ -22,6 +22,8 @@ default: &default
     password: {{ project_fedora_password }}
     base_path: {{ project_fedora_base_path }}
     noid_statefile: {{ project_noid_statefile }}
+  iiif: &iiif
+    cache_duration: {{ iiif_cache_duration }}
   orcid: &orcid
     app_id: {{ project_orcid_app_id }}
     app_secret: {{ project_orcid_app_secret }}


### PR DESCRIPTION
This change allows the Riiif cache_duration parameter to be set via the application's config/secrets.yml file instead of having it be hard-coded in the config/initializers/riiif.rb initializer itself.

This adds a new hierarchy to config/secrets.yml: iiif.  The cache_duration is a key, "cache_duration", which represents to amount of time (in seconds) an object will remain in the Riiif cache.