### PR TITLE
Pass in site_secrets.yml to Vagrant

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -77,6 +77,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # Ansible provisioner default settings
   config.vm.provision vagrant_ansible_provisioner() do |ansible|
     ansible.playbook = "ansible/#{site_file()}_site.yml"
+    ansible.extra_vars = 'ansible/site_secrets.yml'
     ansible.verbose = ""
   end
 

--- a/ansible/geoblacklight_site.yml
+++ b/ansible/geoblacklight_site.yml
@@ -4,7 +4,6 @@
   user: "{{ ansible_user }}"
   vars_files:
     - site_vars.yml
-    - site_secrets.yml
   gather_facts: true
   roles:
     - { role: solr, become: yes, solr_version: "5.5.2" }

--- a/ansible/hyrax_site.yml
+++ b/ansible/hyrax_site.yml
@@ -4,7 +4,6 @@
   user: "{{ ansible_user }}"
   vars_files:
     - site_vars.yml
-    - site_secrets.yml
   gather_facts: true
   roles:
     - {

--- a/ansible/sufia_site.yml
+++ b/ansible/sufia_site.yml
@@ -4,7 +4,6 @@
   user: "{{ ansible_user }}"
   vars_files:
     - site_vars.yml
-    - site_secrets.yml
   gather_facts: true
   roles:
     - {


### PR DESCRIPTION
Currently, the site_secrets.yml vars file that controls much of the application provisioning is a mandatory file that is provided by the person doing the provisioning. Such externally-supplied files are not ideal when using Ansible Tower, which prefers a "pristine" environment in which to deploy, with optional components being supplied by Ansible Tower or fetched as part of the provisioning process.

To make Vagrant act similarly, we pass in the "site_secrets.yml" file explicitly as part of the provisioning process, similar to Ansible Tower's operation.  This is done by way of Vagrant's "extra_vars" mechanism.