### PR TITLE
Install prerequisites for "archive" Gem

### DIFF
--- a/ansible/roles/hyrax/tasks/main.yml
+++ b/ansible/roles/hyrax/tasks/main.yml
@@ -19,6 +19,7 @@
     - libreoffice
     - zlib1g-dev
     - libsqlite3-dev
+    - libarchive-dev
 
 - name: make sure project user owns the application
   file:


### PR DESCRIPTION
Install the libarchive development libraries and headers so the native extensions may be built for the "archive" Gem.