### PR TITLE
Switch to Vagrant "private_network" networking

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,19 +132,18 @@ In the case of the plain `vagrant up` option, a VM will be brought up and config
 
 You can use `vagrant ssh` to log in to this VM when it is up. When logged out of the VM, `vagrant halt` can be used to shut down the VM. The command `vagrant destroy` will destroy it entirely, requiring another `vagrant up` to recreate it.
 
-Several ports in the running VM are made accessible on the local machine.
-Accessing the local port in a Web browser will actually result in the forwarded
-port being accessed on the VM. These ports are as follows:
+The local VM listens on a Vagrant private network that is accessible from only the local host machine. The default IP address of the VM is 10.31.63.127 but may be overridden by setting the `SAMVERA_APP_ID` environment variable on the host system to a different [RFC1918](https://en.wikipedia.org/wiki/Private_network) private IP address. (Note: be consistent in setting this environment variable if you wish to override the default VM IP address, otherwise it may revert back to the default.)
 
-Local | VM   | Description
------ | ---- | -----------
-8983  | 8983 | Solr services
-8888  | 8080 | Tomcat (if applicable)
-8080  | 80   | Application (HTTP)
-4443  | 443  | Application (HTTPS)
+Several notable ports in the running VM are accessible on the local machine. Accessing the port of the VM IP address mentioned above in a Web browser will result in the corresponding service being accessed on the VM. These ports and services are as follows:
 
-To access the Solr admin page in the VM from the local machine you would access
-this URL: `http://localhost:8983/solr`.  (Note that only the "Local" ports in the above table are directly accessible from the local machine.)
+Port | Service
+---- | -------
+8983 | Solr services
+8080 | Tomcat (if applicable)
+80   | Application (HTTP)
+443  | Application (HTTPS)
+
+For example, to access the Solr admin page in the VM from the local machine you would access this URL: `http://10.31.63.127:8983/solr`.  (Replace '10.31.63.127' with the appropriate IP if overridden via `SAMVERA_APP_ID`.)
 
 ### AWS
 

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ In the case of the plain `vagrant up` option, a VM will be brought up and config
 
 You can use `vagrant ssh` to log in to this VM when it is up. When logged out of the VM, `vagrant halt` can be used to shut down the VM. The command `vagrant destroy` will destroy it entirely, requiring another `vagrant up` to recreate it.
 
-The local VM listens on a Vagrant private network that is accessible from only the local host machine. The default IP address of the VM is 10.31.63.127 but may be overridden by setting the `SAMVERA_APP_ID` environment variable on the host system to a different [RFC1918](https://en.wikipedia.org/wiki/Private_network) private IP address. (Note: be consistent in setting this environment variable if you wish to override the default VM IP address, otherwise it may revert back to the default.)
+The local VM listens on a Vagrant private network that is accessible from only the local host machine. The default IP address of the VM is 10.31.63.127 but may be overridden by setting the `SAMVERA_APP_IP` environment variable on the host system to a different [RFC1918](https://en.wikipedia.org/wiki/Private_network) private IP address. (Note: be consistent in setting this environment variable if you wish to override the default VM IP address, otherwise it may revert back to the default.)
 
 Several notable ports in the running VM are accessible on the local machine. Accessing the port of the VM IP address mentioned above in a Web browser will result in the corresponding service being accessed on the VM. These ports and services are as follows:
 
@@ -143,7 +143,7 @@ Port | Service
 80   | Application (HTTP)
 443  | Application (HTTPS)
 
-For example, to access the Solr admin page in the VM from the local machine you would access this URL: `http://10.31.63.127:8983/solr`.  (Replace '10.31.63.127' with the appropriate IP if overridden via `SAMVERA_APP_ID`.)
+For example, to access the Solr admin page in the VM from the local machine you would access this URL: `http://10.31.63.127:8983/solr`.  (Replace '10.31.63.127' with the appropriate IP if overridden via `SAMVERA_APP_IP`.)
 
 ### AWS
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -103,14 +103,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       override.vm.box = "ubuntu/trusty64"
       vb.memory = 4096
       vb.cpus = 2
-      # Forward Solr port in VM to local machine
-      override.vm.network :forwarded_port, host: 8983, guest: 8983
-      # Forward Tomcat/Fedora port in VM to port 8888 on local machine
-      override.vm.network :forwarded_port, host: 8888, guest: 8080
-      # Forward HTTP port in VM to port 8080 on local machine
-      override.vm.network :forwarded_port, host: 8081, guest: 80
-      # Forward HTTPS port in VM to port 4443 on local machine
-      override.vm.network :forwarded_port, host: 4443, guest: 443
+      vm_ip = ENV['SAMVERA_APP_IP'] || '10.31.63.127'
+      override.vm.network :private_network, ip: vm_ip
     end
 
     hydravm.vm.provider :openstack do |os, override|


### PR DESCRIPTION
The current Vagrant network configuration uses standard VirtualBox NAT networking.  This requires port forwarding to reach VM ports from the host and such port forwarding can, pragmatically, require non-standard ports to be forwarded on the host due to elevated privileges required to forward privileged (<1024) ports.  Port forwarding can also expose the local VM to external access.

This change switches the Vagrant VM to run in a Vagrant "private_network" that is accessible only from the host.  This means that port forwarding is generally no longer needed (e.g., to reach Web applications on the VM), which makes local browser access much more akin to accessing a production service.  It also increases VM security, as it is now accessible only from the local system.