### PR TITLE
Switch to Bento Boxes

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -100,7 +100,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     hydravm.vm.provider :virtualbox do |vb, override|
       vb.name = $secrets_items["vm_name"] if !$secrets_items["vm_name"].nil? && !$secrets_items["vm_name"].empty?
       vb.customize ["modifyvm", :id, "--description", "Created from Vagrantfile in #{Dir.pwd}"]
-      override.vm.box = "ubuntu/trusty64"
+      override.vm.box = "bento/ubuntu-14.04"
       vb.memory = 4096
       vb.cpus = 2
       # Forward Solr port in VM to local machine


### PR DESCRIPTION
The Vagrant documentation on boxes (https://www.vagrantup.com/docs/boxes.html) mentions Bento Boxes (https://vagrantcloud.com/bento) as one of only two officially-recommended sources for Vagrant boxes.

One of the advantages of Bento Boxes is that they are open source boxes built using Packer.  This makes them ideal for reproducible builds (and for allowing scrutiny of the build process and box components).  Bento Boxes also support more Vagrant providers than the Vagrant boxes from Canonical that we are currently using.

This change switches to using a Bento Box for the Vagrant box.