### PR TITLE
Pin Passenger version to 5.2.x

### DIFF
--- a/ansible/roles/passenger/tasks/main.yml
+++ b/ansible/roles/passenger/tasks/main.yml
@@ -19,7 +19,7 @@
     update_cache: yes
   with_items:
     - nginx-extras
-    - passenger
+    - passenger=1:5.2.*
 
 - name: unlink default nginx site
   file:


### PR DESCRIPTION
The recently-released 5.3.0 version of Passenger appears to break running Rails applications for our setup.  This commit pins Passenger to version 5.2.x for now.