### PR TITLE
Fix Ansible 2.5 deprecations

### DIFF
--- a/ansible/hyrax_site.yml
+++ b/ansible/hyrax_site.yml
@@ -10,13 +10,13 @@
         role: fedora4,
         become: yes,
         fedora_version: '4.5.1',
-        when: project_fedora_url | search( 'localhost|127\.0\.0\.1' )
+        when: project_fedora_url is search( 'localhost|127\.0\.0\.1' )
     }
     - {
         role: solr,
         become: yes,
         solr_version: '5.5.1',
-        when: project_solr_url | search( 'localhost|127\.0\.0\.1' )
+        when: project_solr_url is search( 'localhost|127\.0\.0\.1' )
     }
     - {
         role: postgresql,
@@ -26,7 +26,7 @@
     - {
         role: redis,
         become: yes,
-        when: project_redis_host | search( 'localhost|127\.0\.0\.1' )
+        when: project_redis_host is search( 'localhost|127\.0\.0\.1' )
     }
     - {
         role: hyrax,

--- a/ansible/roles/chroot-sftp/tasks/sftp_user.yml
+++ b/ansible/roles/chroot-sftp/tasks/sftp_user.yml
@@ -44,11 +44,11 @@
 
 - name: fail if loading authorised keys failed
   fail: msg="Loading authorized_keys failed."
-  when: key_copy|failed
+  when: key_copy is failed
 
 - name: issue a warning if no authorised keys found locally
   debug:
     msg: |
       WARNING: No keys found in {{ local_files_dir }}/authorized_keys directory!
       Upload user will not be able to sftp to system until you provide one.
-  when: key_copy|skipped
+  when: key_copy is skipped

--- a/ansible/roles/fits/tasks/main.yml
+++ b/ansible/roles/fits/tasks/main.yml
@@ -23,7 +23,7 @@
     group: root
     mode: 0444
     timeout: 100
-  when: cached_fits|failed
+  when: cached_fits is failed
 
 - name: cache fits for the future
   fetch:

--- a/ansible/roles/hyrax/tasks/binary-arts.yml
+++ b/ansible/roles/hyrax/tasks/binary-arts.yml
@@ -24,7 +24,7 @@
     command: ./bin/rails binaryarts:upgrade_users
     args:
       chdir: '{{ project_app_root }}'
-    when: copy_admin_list|succeeded
+    when: copy_admin_list is successful
 
   - name: ensure font directory exists
     file:

--- a/ansible/roles/hyrax/tasks/data-repo.yml
+++ b/ansible/roles/hyrax/tasks/data-repo.yml
@@ -16,7 +16,7 @@
     command: ./bin/rails vtechdata:populate_users
     args:
       chdir: '{{ project_app_root }}'
-    when: copy_user_list|succeeded
+    when: copy_user_list is successful
 
   - name: remove list of users
     file:

--- a/ansible/roles/hyrax/tasks/hyrax2.yml
+++ b/ansible/roles/hyrax/tasks/hyrax2.yml
@@ -21,7 +21,7 @@
     command: bundle exec rails vt_hyrax2:populate_users
     args:
       chdir: '{{ project_app_root }}'
-    when: copy_user_list|succeeded
+    when: copy_user_list is successful
 
   - name: copy list of admins
     copy:
@@ -39,7 +39,7 @@
     command: bundle exec rails vt_hyrax2:upgrade_users
     args:
       chdir: '{{ project_app_root }}'
-    when: copy_admin_list|succeeded
+    when: copy_admin_list is successful
   become: yes
   become_user: '{{ project_runner }}'
   environment:

--- a/ansible/roles/hyrax/tasks/iawa.yml
+++ b/ansible/roles/hyrax/tasks/iawa.yml
@@ -21,7 +21,7 @@
     command: bundle exec rails iawa:populate_users
     args:
       chdir: '{{ project_app_root }}'
-    when: copy_user_list|succeeded
+    when: copy_user_list is successful
 
   - name: copy list of admins
     copy:
@@ -39,7 +39,7 @@
     command: bundle exec rails iawa:upgrade_users
     args:
       chdir: '{{ project_app_root }}'
-    when: copy_admin_list|succeeded
+    when: copy_admin_list is successful
 
   - name: add initial controlled vocabularies
     command: bundle exec rails iawa:add_controlled_vocabs

--- a/ansible/roles/hyrax/tasks/main.yml
+++ b/ansible/roles/hyrax/tasks/main.yml
@@ -48,7 +48,7 @@
     owner: '{{ project_owner }}'
     group: '{{ project_owner_group }}'
     mode: 0600
-  when: clone_app|failed
+  when: clone_app is failed
 
 - name: clone the repo with a deploy key.
   git:
@@ -58,7 +58,7 @@
     key_file: '{{ project_owner_home }}/.ssh/deploy_key'
     force: yes
   become_user: "{{ project_owner }}"
-  when: clone_app|failed
+  when: clone_app is failed
   register: deploy_app
   notify:
     - restart nginx
@@ -71,7 +71,7 @@
 
 - name: create the project's solr cores
   include: solr_core_setup.yml
-  when: project_solr_url | search( 'localhost|127\.0\.0\.1' )
+  when: project_solr_url is search( 'localhost|127\.0\.0\.1' )
 
 - name: make sure application runs as project_runner
   file:

--- a/ansible/roles/hyrax/tasks/solr_core_setup.yml
+++ b/ansible/roles/hyrax/tasks/solr_core_setup.yml
@@ -34,7 +34,7 @@
       mode: 0444
       remote_src: True
     notify: restart solr
-    when: hyrax_solrconfig|failed
+    when: hyrax_solrconfig is failed
     register: solrconfig
     ignore_errors: True
   - name: copy sufia's solrconfig.xml to the core from a legacy location
@@ -46,7 +46,7 @@
       mode: 0444
       remote_src: True
     notify: restart solr
-    when: solrconfig|failed
+    when: solrconfig is failed
   - name: copy hyrax's schema.xml to the core
     copy:
       src: '{{ project_app_root }}/solr/conf/schema.xml'
@@ -67,7 +67,7 @@
       mode: 0444
       remote_src: True
     notify: restart solr
-    when: hyrax_schema|failed
+    when: hyrax_schema is failed
     register: schema
     ignore_errors: True
   - name: copy sufia's schema.xml to the core from a legacy location
@@ -79,7 +79,7 @@
       mode: 0444
       remote_src: True
     notify: restart solr
-    when: schema|failed
+    when: schema is failed
 
   - name: copy hyrax's synonyms.txt to the core
     copy:
@@ -164,7 +164,7 @@
       mode: 0444
       remote_src: True
     notify: restart solr
-    when: hyrax_test_solrconfig|failed
+    when: hyrax_test_solrconfig is failed
     register: test_solrconfig
     ignore_errors: True
   - name: copy sufia's solrconfig.xml to the test core from a legacy location
@@ -176,7 +176,7 @@
       mode: 0444
       remote_src: True
     notify: restart solr
-    when: test_solrconfig|failed
+    when: test_solrconfig is failed
   - name: copy hyrax's schema.xml to the test core
     copy:
       src: '{{ project_app_root }}/solr/conf/schema.xml'
@@ -197,7 +197,7 @@
       mode: 0444
       remote_src: True
     notify: restart solr
-    when: hyrax_test_schema|failed
+    when: hyrax_test_schema is failed
     register: test_schema
     ignore_errors: True
   - name: copy sufia's schema.xml to the test core from a legacy location
@@ -209,7 +209,7 @@
       mode: 0444
       remote_src: True
     notify: restart solr
-    when: test_schema|failed
+    when: test_schema is failed
   - name: copy hyrax's synonyms.txt to the test core
     copy:
       src: '{{ project_app_root }}/solr/conf/synonyms.txt'

--- a/ansible/roles/phantomjs/tasks/main.yml
+++ b/ansible/roles/phantomjs/tasks/main.yml
@@ -16,7 +16,7 @@
     get_url:
       url: https://bitbucket.org/ariya/phantomjs/downloads/{{ phantomjs_src }}
       dest: /tmp/{{ phantomjs_src }}
-    when: cached_pjs|failed
+    when: cached_pjs is failed
 
   - name: unzip phantomjs
     command: '/bin/tar --extract --bzip2 --file="/tmp/{{ phantomjs_src }}" --directory="{{ phantomjs_dir }}" --strip-components=1'

--- a/ansible/roles/postgresql/defaults/main.yml
+++ b/ansible/roles/postgresql/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
 # PostgreSQL-related settings
-postgresql_is_local: "{{ 'true' if project_db_host | search( 'localhost|127\\.0\\.0\\.1|^/') else 'false' }}"
+postgresql_is_local: "{{ 'true' if project_db_host is search( 'localhost|127\\.0\\.0\\.1|^/') else 'false' }}"

--- a/ansible/roles/sufia/tasks/data-repo.yml
+++ b/ansible/roles/sufia/tasks/data-repo.yml
@@ -16,7 +16,7 @@
     command: bundle exec rake datarepo:populate_users
     args:
       chdir: '{{ project_app_root }}'
-    when: copy_user_list|succeeded
+    when: copy_user_list is successful
 
   - name: remove list of users
     file:
@@ -34,7 +34,7 @@
     command: bundle exec rake datarepo:upgrade_users
     args:
       chdir: '{{ project_app_root }}'
-    when: copy_admin_list|succeeded
+    when: copy_admin_list is successful
 
   - name: remove list of admins
     file:

--- a/ansible/roles/sufia/tasks/main.yml
+++ b/ansible/roles/sufia/tasks/main.yml
@@ -42,7 +42,7 @@
     owner: '{{ project_owner }}'
     group: '{{ project_owner_group }}'
     mode: 0600
-  when: clone_app|failed
+  when: clone_app is failed
 
 - name: clone the repo with a deploy key.
   git:
@@ -52,7 +52,7 @@
     key_file: '{{ project_owner_home }}/.ssh/deploy_key'
     force: yes
   become_user: "{{ project_owner }}"
-  when: clone_app|failed
+  when: clone_app is failed
   register: deploy_app
   notify:
     - restart nginx
@@ -65,7 +65,7 @@
 
 - name: create the project's solr cores
   include: solr_core_setup.yml
-  when: project_solr_url | search( 'localhost|127\.0\.0\.1' )
+  when: project_solr_url is search( 'localhost|127\.0\.0\.1' )
 
 - name: make sure application runs as project_runner
   file:

--- a/ansible/roles/sufia/tasks/solr_core_setup.yml
+++ b/ansible/roles/sufia/tasks/solr_core_setup.yml
@@ -34,7 +34,7 @@
       mode: 0444
       remote_src: True
     notify: restart solr
-    when: solrconfig|failed
+    when: solrconfig is failed
   - name: copy sufia's schema.xml to the core
     copy:
       src: '{{ project_app_root }}/solr/config/schema.xml'
@@ -55,7 +55,7 @@
       mode: 0444
       remote_src: True
     notify: restart solr
-    when: schema|failed
+    when: schema is failed
 
 - block:
   - name: create sufia solr test core
@@ -92,7 +92,7 @@
       mode: 0444
       remote_src: True
     notify: restart solr
-    when: test_solrconfig|failed
+    when: test_solrconfig is failed
   - name: copy sufia's schema.xml to the test core
     copy:
       src: '{{ project_app_root }}/solr/config/schema.xml'
@@ -113,5 +113,5 @@
       mode: 0444
       remote_src: True
     notify: restart solr
-    when: test_schema|failed
+    when: test_schema is failed
   when: project_app_env == 'development'

--- a/ansible/roles/tls_cert/tasks/main.yml
+++ b/ansible/roles/tls_cert/tasks/main.yml
@@ -34,7 +34,7 @@
   args:
     chdir: /tmp
   notify: restart nginx
-  when: local_cert|failed or local_key|failed
+  when: local_cert is failed or local_key is failed
 
 - name: copy tls cert and key for reuse in vagrant
   fetch:

--- a/ansible/sufia_site.yml
+++ b/ansible/sufia_site.yml
@@ -10,13 +10,13 @@
         role: fedora4,
         become: yes,
         fedora_version: '4.5.1',
-        when: project_fedora_url | search( 'localhost|127\.0\.0\.1' )
+        when: project_fedora_url is search( 'localhost|127\.0\.0\.1' )
     }
     - {
         role: solr,
         become: yes,
         solr_version: '5.5.1',
-        when: project_solr_url | search( 'localhost|127\.0\.0\.1' )
+        when: project_solr_url is search( 'localhost|127\.0\.0\.1' )
     }
     - {
         role: postgresql,
@@ -26,7 +26,7 @@
     - {
         role: redis,
         become: yes,
-        when: project_redis_host | search( 'localhost|127\.0\.0\.1' )
+        when: project_redis_host is search( 'localhost|127\.0\.0\.1' )
     }
     - {
         role: sufia,


### PR DESCRIPTION
In Ansible 2.5 , using Jinja tests as filters is deprecated (https://docs.ansible.com/ansible/2.5/porting_guides/porting_guide_2.5.html#jinja-tests-used-as-filters).  This leads to a lot of deprecation warnings in the current Ansible playbooks.

This commit fixes those deprecations, leading to "cleaner" playbook runs.