### PR TITLE
Fix FITS version defaults

### DIFF
--- a/ansible/roles/fits/defaults/main.yml
+++ b/ansible/roles/fits/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
-fits_version: "{{ '0.8.5' if project_name == 'iawa' else '0.6.2' }}"
+fits_version: "{% if project_name == 'data-repo' %}0.6.2{% elif project_name == 'iawa' %}0.8.5{% else %}1.0.5{% endif %}"
 fits_download_url: http://projects.iq.harvard.edu/files/fits/files


### PR DESCRIPTION
Hyrax 2.x applications are recommended to use FITS 1.0.5.  The current code chose a default based upon "project_name" that allowed only the possibility of version 0.8.5 or 0.6.2.

This change corrects the setting of the default value of FITS so it is appropriate for our current projects.  Note: "fits_version" can always be explicitly overridden in the "ansible/site_secrets.yml" file when deploying.