### PR TITLE
Sunset EZID settings

### DIFF
--- a/ansible/example_site_secrets.yml
+++ b/ansible/example_site_secrets.yml
@@ -53,6 +53,12 @@ graylog_verbosity: "info"
 #
 # The GeoNames user the application will use (if any)
 project_geonames_user: ''
+# EZID shoulder
+project_ezid_shoulder: 'doi:10.5072/FK2'
+# EZID API username
+project_ezid_user: 'apitest'
+# EZID API password
+project_ezid_password: 'apitest'
 # DOI host
 project_doi_host: 'https://ez.datacite.org/'
 # DOI shoulder

--- a/ansible/roles/hyrax/templates/secrets.yml.j2
+++ b/ansible/roles/hyrax/templates/secrets.yml.j2
@@ -12,6 +12,10 @@ default: &default
     password: {{ project_db_password }}
     host: {{ project_db_host }}
     #port: 5432         # TCP/IP port of database server
+  ezid: &ezid
+    default_shoulder: {{ project_ezid_shoulder }}
+    user: {{ project_ezid_user }}
+    password: {{ project_ezid_password }}
   doi: &doi
     host: {{ project_doi_host }}
     default_shoulder: {{ project_doi_shoulder }}

--- a/ansible/roles/sufia/templates/secrets.yml.j2
+++ b/ansible/roles/sufia/templates/secrets.yml.j2
@@ -12,6 +12,10 @@ default: &default
     password: {{ project_db_password }}
     host: {{ project_db_host }}
     #port: 5432         # TCP/IP port of database server
+  ezid: &ezid
+    default_shoulder: {{ project_ezid_shoulder }}
+    user: {{ project_ezid_user }}
+    password: {{ project_ezid_password }}
   doi: &doi
     host: {{ project_doi_host }}
     default_shoulder: {{ project_doi_shoulder }}
@@ -51,7 +55,7 @@ default: &default
   osf:
     client_id: {{ project_osf_client_id }}
     client_secret: {{ project_osf_client_secret }}
-    
+
 # These are the settings applicable for RAILS_ENV=development.  They inherit
 # settings from the above "default".
 development:


### PR DESCRIPTION
The previous DOI provider, EZID, had config/secrets.yml referenced under the key space of "ezid".  When this was changed to the more generic key space of "doi", older applications that still referenced "ezid" broke due to the absence of that key hierarchy in config/secrets.yml.

This change restores the old "ezid" settings alongside the new, preferred "doi" settings, for backwards compatibility with applications that have yet to update to using "doi".

Note that the "ezid" keys are now deprecated and should be removed in the future.