### PR TITLE
LIBTD-1418: Short-term fix: Compel Default CollectionTypes

### DIFF
--- a/ansible/roles/hyrax/tasks/compel.yml
+++ b/ansible/roles/hyrax/tasks/compel.yml
@@ -1,7 +1,7 @@
 ---
 - block:
-  - name: create default collection type
-    command: bundle exec rails compel:create_default_collection_type
+  - name: create default hyrax collection type
+    command: bundle exec rails hyrax:default_collection_types:create
     args:
       chdir: '{{ project_app_root }}'
 


### PR DESCRIPTION
To be tested with https://github.com/VTUL/compel/tree/LIBTD-1418

Temporary solution in order to create the default Hyrax Collection Types.

One way of testing it out is to:
1. Sign up as a user
2. Create an `admin_list.txt` file with your email address:
   ```
   echo "me@example.org" > admin_list.txt
   ``` 
3. Run the rake task to elevate your user to admin status:
   ```
   bin/rails compel:upgrade_users
   ```
4. Check out the Collection Types in the dashboard to see if "User Collection" and 
Admin Set" have been created properly.

<img width="1196" alt="screen shot 2018-07-16 at 4 21 18 pm" src="https://user-images.githubusercontent.com/20912658/42781645-b72e1ca8-8914-11e8-8847-39d83fadd9f2.png">
