### PR TITLE
Make "clamav" role work for redeployments

### DIFF
--- a/ansible/roles/clamav/tasks/main.yml
+++ b/ansible/roles/clamav/tasks/main.yml
@@ -24,17 +24,18 @@
     state: absent
   when: not clamav_private_mirror_enabled
 
-- name: stop clamav so that database update can happen
+- name: stop clamav so that manual database update can happen
   service:
     name: clamav-freshclam
     state: stopped
 
 - name: create/update the clamav databases
   command: /usr/bin/freshclam --quiet
-  args:
-    creates: /var/lib/clamav/main.cvd
+  register: freshclam_cmd
+  failed_when: freshclam_cmd.rc > 1
 
-- name: start clamav if stopped
+- name: start clamav and enable to run at boot
   service:
     name: clamav-freshclam
     state: started
+    enabled: yes


### PR DESCRIPTION
# Make `clamav` role work for redeployments
* * *

# JIRA Ticket: [LIBTD-1476](https://webapps.es.vt.edu/jira/browse/LIBTD-1476)

# What does this Pull Request do?

This change allows Samvera applications to be redeployed without failing in the `clamav` role.

# What's the changes?

The `clamav` role is designed to ensure that virus definitions are present when deploying so that Samvera applications will subsequently start up. (If virus definitions are not present, the ClamAV Gem will fail to initialise.)

To ensure virus definitions are present and usable, the `clamav` role stops the `clamav-freshclam` service; invokes `freshclam` explicitly to create/update the virus definition files; and then starts the `clamav-freshclam` service again. The `freshclam` command is invoked using the Ansible `command` module.

Unfortunately, despite information in the `freshclam` man page to the contrary, `freshclam` returns a return code of 1 (not 0) if the virus definition files are updated or up to date. This return code is interpreted as a command failure by Ansible, and it considers the play task to have failed.

This error is normally only provoked when reprovisioning. On a fresh deployment, installation of ClamAV itself causes initial virus definitions to be placed in `/var/lib/clamav` and the `creates` argument to the `freshclam` invocation via `command` causes the `freshclam` update to be skipped. Subsequent updates via the `clamav-freshclam` service normally result in updated files with `.cld` extensions, which will cause the `freshclam` command to execute, as it checks for the presence of a `/var/lib/clamav/main.cvd` file.

This change fixes the `freshclam` command module execution by considering only return codes > 1 to be an error.  It also removes the `creates` argument that causes the update to be skipped when any virus definitions are present, as these may be very stale: it is the responsibility of `freshclam` to decide whether or not updates are needed.

Also, this update explicitly enables the `clamav-freshclam` service to run at system boot.  Previously, this was an implicit side-effect of package installation.

# How should this be tested?

Test this change by deploying one of our Samvera applications and then redeploy it, e.g.:
* Check out fresh the `LIBTD-1476` branch of `VTUL/InstallScripts`
* Create `ansible/site_secrets.yml` to deploy a Samvera application, e.g., `compel`
* Execute `vagrant up`
* Execute `vagrant provision`

In the last two steps, a successful test will have `failed=0` each time in the `PLAY RECAP` at the end.

# Interested parties
@shabububu 
