### PR TITLE
LIBTD-1257: Adding creation of default hyrax collection types for IAWA (Hyrax 2.1.0)

### DIFF
--- a/ansible/roles/hyrax/tasks/iawa.yml
+++ b/ansible/roles/hyrax/tasks/iawa.yml
@@ -1,5 +1,10 @@
 ---
 - block:
+  - name: create default hyrax collection type
+    command: bundle exec rails hyrax:default_collection_types:create
+    args:
+      chdir: '{{ project_app_root }}'
+
   - name: create roles
     command: bundle exec rails iawa:add_roles
     args:


### PR DESCRIPTION
**JIRA Ticket**: https://webapps.es.vt.edu/jira/browse/LIBTD-1257

* Other Relevant Links: This PR should be reviewed and merged in coordination with https://github.com/VTUL/iawa/pull/99

# What does this Pull Request do? 
This PR adds the creation of the default Hyrax collection types (Admin Set and User Collections) to InstallScripts. This change is the result of the migration of IAWA from Hyrax 1.0.4 to 2.1.0.

# What are the changes?
InstallScripts will now run `bundle exec rails hyrax:default_collection_types:create` for IAWA.

# How should this be tested?

To test this, please use the InstallScripts branch `LIBTD-1257`. This will ensure that the appropriate default Hyrax CollectionTypes are installed. Also, use the following settings in your `site_secrets.yml` :

```
project_name: 'iawa'
project_git_identifier: 'LIBTD-1256'
project_app_env: 'production'
```

Note that the `project_secret_key_base` and `project_cas_url` will also need to be updated.

Try the following:
* Log in as an administrator. Check to make sure that both `Admin Sets` and `User Collections` are available from the dashboard configuration Collection Types.
* Attempt to create a collection, both with and without branding images.

# Additional Notes:
If changes are acceptable, please coordinate the merge with the merging of https://github.com/VTUL/iawa/pull/99 into the `iawa` master branch.

# Interested parties
@tingtingjh 
