### PR TITLE
Add support for installing Google Chrome

### DIFF
--- a/ansible/roles/chrome/README.md
+++ b/ansible/roles/chrome/README.md
@@ -1,0 +1,14 @@
+Chrome
+======
+
+Installs the Google Chrome browser.
+
+Requirements
+------------
+
+This requires our Common role.
+
+Role Variables
+--------------
+
+- `chrome_branch`: The desired release stream of Google Chrome: `stable`, `unstable`, or `beta`.  (Default: `stable`)

--- a/ansible/roles/chrome/defaults/main.yml
+++ b/ansible/roles/chrome/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+chrome_branch: stable

--- a/ansible/roles/chrome/meta/main.yml
+++ b/ansible/roles/chrome/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - { role: common }

--- a/ansible/roles/chrome/tasks/main.yml
+++ b/ansible/roles/chrome/tasks/main.yml
@@ -1,0 +1,20 @@
+---
+- name: add chrome apt key
+  apt_key:
+    url: https://dl-ssl.google.com/linux/linux_signing_key.pub
+    id: 7FAC5991
+    state: present
+
+- name: add chrome apt repo
+  apt_repository:
+    repo: 'deb [arch=amd64] https://dl.google.com/linux/chrome/deb/ stable main'
+    state: present
+    update_cache: yes
+
+- name: install google-chrome
+  apt:
+    name: google-chrome-{{ chrome_branch }}
+    state: present
+    force: yes
+    cache_valid_time: '{{ apt_cache_timeout }}'
+    update_cache: yes

--- a/ansible/roles/hyrax/meta/main.yml
+++ b/ansible/roles/hyrax/meta/main.yml
@@ -10,5 +10,6 @@ dependencies:
   - { role: postfix }
   - { role: nodejs, nodejs_version: '6.x' }
   - { role: phantomjs, phantomjs_version: '2.1.1', when: project_app_env != 'production' }
+  - { role: chrome, when: project_app_env != 'production' }
   - { role: ruby, ruby_version: '2.3' }
   - { role: local_files }


### PR DESCRIPTION
**Add support for installing Google Chrome**
* * *


# What does this Pull Request do?

Add a role to enable Google Chrome to be installed.  This is used in the Rails "test" and "development" environments to run feature tests using Google Chrome in "headless" mode via "chromedriver".

# What's the changes?

* Add `chrome` Ansible role that may be used to install Google Chrome
* Amend `hyrax` role to add `chrome` role as a dependency (so it will be installed) except when deploying in `production` mode

# How should this be tested?

* Set `ansible/site_secrets.yml` to deploy a Hyrax application, e.g., `compel`
* Run `vagrant up` to deploy the application
* Log into the resultant local VM via `vagrant ssh`
* Run `which google-chrome` command
* Run `google-chrome --version` command

# Additional Notes:

The expected output from the last two commands above is as follows:
```
vagrant@compel:~$ which google-chrome
/usr/bin/google-chrome
vagrant@compel:~$ google-chrome --version
Google Chrome 69.0.3497.100
```

# Interested parties

@shabububu 
