### PR TITLE
Remove hard-coded Passenger version

### DIFF
--- a/ansible/roles/passenger/defaults/main.yml
+++ b/ansible/roles/passenger/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+# Passenger-related settings
+passenger_version: 1:5.3.*

--- a/ansible/roles/passenger/tasks/main.yml
+++ b/ansible/roles/passenger/tasks/main.yml
@@ -20,7 +20,7 @@
     update_cache: yes
   with_items:
     - nginx-extras
-    - passenger=1:5.2.*
+    - passenger={{ passenger_version }}
 
 - name: unlink default nginx site
   file:


### PR DESCRIPTION
**Remove hard-coded Passenger version**
* * *

# What does this Pull Request do?

Passenger broke during the 5.2.x to 5.3.x lifecycle transition.  Our fix at that time was to pin Passenger at the working 5.2.x release.  Unfortunately, the older 5.2.x version has now broken, whereas the latest version (5.3.5) works.

To prevent problems arising from static pinning, this change introduces an Ansible variable, `passenger_version`, which may be used to specify which version of the Passenger package is desired to be installed.

Although this is set statically in `roles/passenger/defaults/main.yml` it may be overridden elsewhere, e.g., via a definition in `site_secrets.yml` when deploying, should a different Passenger version be wanted.

# What's the changes?

* Removed pin to hard-coded version of Passenger and replaced it with variable (`passenger_version`);
* Provided default version for `passenger_version`.

# How should this be tested?

Deploy an application that uses Passenger, e.g., VTUL/compel.  The application should run and not fail with a Passenger error.

# Interested parties

@tingtingjh @soumikgh 