### PR TITLE
Fix Ansible 2.7 apt/pip deprecations

### DIFF
--- a/ansible/roles/clamav/tasks/main.yml
+++ b/ansible/roles/clamav/tasks/main.yml
@@ -1,13 +1,10 @@
 ---
 - name: install clamav
   apt:
-    name: '{{ item }}'
+    name: ['clamav', 'libclamav-dev']
     state: present
     cache_valid_time: '{{ apt_cache_timeout }}'
     update_cache: yes
-  with_items:
-    - clamav
-    - libclamav-dev
 
 - name: use local private mirror if enabled
   lineinfile:

--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -22,18 +22,12 @@
 
 - name: install building software and build essentials
   apt:
-    name: '{{ item }}'
+    name: '{{ common_essential_packages }}'
     state: present
     cache_valid_time: '{{ apt_cache_timeout }}'
     update_cache: yes
-  with_items: "{{ common_essential_packages }}"
 
 - name: update python's crypto libs
   pip:
-    name: '{{ item }}'
-  with_items:
-    - urllib3
-    - pyopenssl
-    - ndg-httpsclient
-    - pyasn1
+    name: ['urllib3', 'pyopenssl', 'ndg-httpsclient', 'pyasn1']
   when: ansible_distribution == "Ubuntu" and ansible_distribution_major_version == '14'

--- a/ansible/roles/fits/tasks/main.yml
+++ b/ansible/roles/fits/tasks/main.yml
@@ -1,12 +1,10 @@
 ---
 - name: install fits installation dependencies
   apt:
-    name: "{{ item }}"
+    name: ['unzip']
     state: present
     cache_valid_time: '{{ apt_cache_timeout }}'
     update_cache: yes
-  with_items:
-    - unzip
 
 - name: copy cached fits
   copy:

--- a/ansible/roles/geoblacklight/tasks/main.yml
+++ b/ansible/roles/geoblacklight/tasks/main.yml
@@ -1,15 +1,10 @@
 ---
 - name: install common rails dependencies
   apt:
-    name: '{{ item }}'
+    name: ['git', 'sqlite3', 'libsqlite3-dev', 'zlib1g-dev']
     state: present
     cache_valid_time: '{{ apt_cache_timeout }}'
     update_cache: yes
-  with_items:
-    - git
-    - sqlite3
-    - libsqlite3-dev
-    - zlib1g-dev
 
 - name: geoblacklight requires a newer version of RubyGems
   command: gem update --system

--- a/ansible/roles/hyrax/tasks/main.yml
+++ b/ansible/roles/hyrax/tasks/main.yml
@@ -20,11 +20,10 @@
 
 - name: install apt dependencies
   apt:
-    name: '{{ item }}'
+    name: '{{ hyrax_dependent_packages }}'
     state: present
     cache_valid_time: '{{ apt_cache_timeout }}'
     update_cache: yes
-  with_items: '{{ hyrax_dependent_packages }}'
 
 - name: make sure project user owns the application
   file:

--- a/ansible/roles/java8/tasks/main.yml
+++ b/ansible/roles/java8/tasks/main.yml
@@ -14,11 +14,7 @@
 
 - name: Install Oracle Java 8 and set as default
   apt:
-    name: '{{ item }}'
+    name: ['oracle-java8-installer', 'ca-certificates', 'oracle-java8-set-default']
     cache_valid_time: '{{ apt_cache_timeout }}'
     update_cache: yes
     state: latest
-  with_items:
-    - oracle-java8-installer
-    - ca-certificates
-    - oracle-java8-set-default

--- a/ansible/roles/passenger/tasks/main.yml
+++ b/ansible/roles/passenger/tasks/main.yml
@@ -13,14 +13,11 @@
 
 - name: nginx and passenger installation
   apt:
-    name: '{{ item }}'
+    name: ['nginx-extras', 'passenger={{ passenger_version }}']
     state: present
     force: yes
     cache_valid_time: '{{ apt_cache_timeout }}'
     update_cache: yes
-  with_items:
-    - nginx-extras
-    - passenger={{ passenger_version }}
 
 - name: unlink default nginx site
   file:

--- a/ansible/roles/postfix/tasks/main.yml
+++ b/ansible/roles/postfix/tasks/main.yml
@@ -13,13 +13,10 @@
 
 - name: install postfix application
   apt:
-    name: '{{ item }}'
+    name: ['postfix', 'mailutils']
     state: present
     cache_valid_time: '{{ apt_cache_timeout }}'
     update_cache: yes
-  with_items:
-    - postfix
-    - mailutils
 
 - name: set postfix listening interfaces
   lineinfile:

--- a/ansible/roles/postgresql/tasks/main.yml
+++ b/ansible/roles/postgresql/tasks/main.yml
@@ -25,21 +25,18 @@
 
 - name: install postgresql server packages
   apt:
-    name: '{{ item }}'
+    name: ['postgresql-{{ postgres_version }}']
     state: present
     cache_valid_time: '{{ apt_cache_timeout }}'
     update_cache: yes
-  with_items:
-    - postgresql-{{ postgres_version }}
   when: postgresql_is_local
 
 - name: install postgresql client packages
   apt:
-    name: '{{ item }}'
+    name: '{{ postgresql_client_packages }}'
     state: present
     cache_valid_time: '{{ apt_cache_timeout }}'
     update_cache: yes
-  with_items: "{{ postgresql_client_packages }}"
 
 - name: install access rules
   copy:

--- a/ansible/roles/ruby/tasks/main.yml
+++ b/ansible/roles/ruby/tasks/main.yml
@@ -7,13 +7,12 @@
 
 - name: install Brightbox Ruby package
   apt:
-    name: '{{ item }}'
+    name:
+      - ruby{{ ruby_version | default('2.3') }}
+      - ruby{{ ruby_version | default('2.3') }}-dev
     state: present
     cache_valid_time: '{{ apt_cache_timeout }}'
     update_cache: yes
-  with_items:
-    - ruby{{ ruby_version | default('2.3') }}
-    - ruby{{ ruby_version | default('2.3') }}-dev
 
 - name: install bundler
   gem:

--- a/ansible/roles/sufia/tasks/main.yml
+++ b/ansible/roles/sufia/tasks/main.yml
@@ -13,11 +13,10 @@
 
 - name: install apt dependencies
   apt:
-    name: '{{ item }}'
+    name: '{{ sufia_dependent_packages }}'
     state: present
     cache_valid_time: '{{ apt_cache_timeout }}'
     update_cache: yes
-  with_items: '{{ sufia_dependent_packages }}'
 
 - name: make sure project user owns the application
   file:

--- a/ansible/roles/tomcat7/tasks/main.yml
+++ b/ansible/roles/tomcat7/tasks/main.yml
@@ -1,13 +1,10 @@
 ---
 - name: ensure tomcat7 packages are installed
   apt:
-    name: '{{ item }}'
+    name: ['tomcat7', 'tomcat7-admin']
     cache_valid_time: '{{ apt_cache_timeout }}'
     update_cache: yes
     state: present
-  with_items:
-    - tomcat7
-    - tomcat7-admin
 
 - name: copy tomcat 7 config file
   template:


### PR DESCRIPTION
**Fix Ansible 2.7 apt/pip deprecations**
* * *

# What does this Pull Request do?

Ansible 2.7 now deprecates the use of loops to install multiple packages with "apt" or "pip".  Instead, the preferred method is to supply a list of packages when multiple packages are being installed.

This commit changes all uses of loops ("with_items" constructs) in conjunction with the "apt" or "pip" modules to use lists or list variables instead.  The deprecated loops feature will be removed entirely in Ansible 2.11.

# What's the changes?

All current use of the "with_items" looping mechanism has been removed in the case of the "apt" and "pip" modules and replaced with lists instead. This silences deprecation warnings relating to that idiom.

# How should this be tested?

Deploy an application using InstallScripts using both Ansible 2.6 and 2.7.  There should be no `[DEPRECATION WARNING]` log entries and the application should deploy successfully in either case.

# Interested parties
@soumikgh 
