### PR TITLE
Support locally-supplied Fedora WAR file

### DIFF
--- a/ansible/roles/fedora4/README.md
+++ b/ansible/roles/fedora4/README.md
@@ -18,6 +18,8 @@ Role variables are listed below, along with their defaults:
     fedora_user_home: /var/local/<tomcat_user>
     fedora_data_dir: /var/local/<tomcat_user>/fedora-data
     fedora_app_dir: /var/lib/<tomcat_user>/webapps
+    fedora_war_filename: fcrepo-webapp-<fedora_version>.war
+    fedora_war_base_url: http://repo1.maven.org/maven2/org/fcrepo/fcrepo-webapp/<fedora_version>
     fedora_java_vm_opts: -Xms512m -Xmx1024m -XX:NewSize=256m -XX:MaxNewSize=256m -XX:MetaspaceSize=256m -XX:MaxMetaspaceSize=256m -XX:+DisableExplicitGC
 
 

--- a/ansible/roles/fedora4/defaults/main.yml
+++ b/ansible/roles/fedora4/defaults/main.yml
@@ -4,4 +4,6 @@ fedora_group: '{{ fedora_user }}'
 fedora_user_home: '/var/local/{{ fedora_user }}'
 fedora_data_dir: '{{ fedora_user_home }}/fedora-data'
 fedora_app_dir: '/var/lib/{{ tomcat_user }}/webapps'
+fedora_war_filename: 'fcrepo-webapp-{{ fedora_version }}.war'
+fedora_war_base_url: 'http://repo1.maven.org/maven2/org/fcrepo/fcrepo-webapp/{{ fedora_version }}'
 fedora_java_vm_opts: "{{ project_fedora_java_vm_opts | default('-Xms512m -Xmx1024m -XX:NewSize=256m -XX:MaxNewSize=256m -XX:MetaspaceSize=256m -XX:MaxMetaspaceSize=256m -XX:+DisableExplicitGC') }}"

--- a/ansible/roles/fedora4/tasks/main.yml
+++ b/ansible/roles/fedora4/tasks/main.yml
@@ -21,14 +21,25 @@
     group: '{{ fedora_group }}'
     state: directory
 
-- name: download fedora war
+- name: copy local fedora war file if it exists
+  copy:
+    src: '{{ local_files_dir }}/{{ fedora_war_filename }}'
+    dest: '{{ fedora_app_dir }}/fedora.war'
+    owner: '{{ fedora_user }}'
+    group: '{{ fedora_group }}'
+    mode: 0444
+  register: local_war_file
+  ignore_errors: True
+
+- name: download fedora war from remote if not locally provided
   get_url:
-    url: http://repo1.maven.org/maven2/org/fcrepo/fcrepo-webapp/{{ fedora_version }}/fcrepo-webapp-{{ fedora_version }}.war
+    url: '{{ fedora_war_base_url }}/{{ fedora_war_filename }}'
     dest: '{{ fedora_app_dir }}/fedora.war'
     owner: '{{ fedora_user }}'
     group: '{{ fedora_group }}'
     mode: 0444
     timeout: 100
+  when: local_war_file is failed
 
 - name: add fedora and java config options to tomcat
   lineinfile:


### PR DESCRIPTION
**Support locally-supplied Fedora WAR file**
* * *

# What does this Pull Request do?
Allows a locally-supplied Fedora WAR file to be used when deploying Fedora 4.

# What's the changes?
Up to now, only official distribution Fedora WAR files can be used when installing Fedora 4.  In some cases, it is desirable to use a locally-patched or otherwise locally-produced Fedora WAR file instead.

This change allows a Fedora WAR file to be placed in the `local_files` directory and used in preference to the distribution version when installing Fedora 4.  If a local WAR file is not present, it will fall back on using the distribution version, as normal.

The `fedora_war_filename` Ansible variable denotes the name of the Fedora WAR file that is used, if present, in `local_files`.  This filename is also used for the fall-back distribution WAR file, so the `local_files` version should have the same name as the Fedora distribution version.

# How should this be tested?

Place a copy of the `fcrepo-webapp-4.5.1.war` file in the `local_files` directory and deploy a Samvera application.  The application should deploy using the locally-supplied WAR file.

Repeat the process afresh, this time without the local WAR file present.  The application should deploy using the fall-back distribution version.

# Interested parties
@soumikgh 