### PR TITLE
LIBTD-1623: Add /derivatives path to Hyrax-based applications (keep /tmp/derivativ…

### DIFF
--- a/ansible/roles/hyrax/tasks/main.yml
+++ b/ansible/roles/hyrax/tasks/main.yml
@@ -100,6 +100,8 @@
       mode: "u=rwX,g=rwXs,o="
     - path: "{{ project_app_root }}/tmp/derivatives"
       mode: "u=rwX,g=rwXs,o="
+    - path: "{{ project_app_root }}/derivatives"
+      mode: "u=rwX,g=rwXs,o="
     - path: "{{ project_app_root }}/tmp/uploads"
       mode: "u=rwX,g=rwXs,o="
     - path: "{{ project_app_root }}/tmp/cache/assets/sprockets/v3.0"


### PR DESCRIPTION
…es for now)

**JIRA Ticket**: https://webapps.es.vt.edu/jira/browse/LIBTD-1623

# What does this Pull Request do?
This PR adds a `{{ project_app_root }}/derivatives` directory to Hyrax-based applications. For the IAWA project, this part of an attempt to pull the derivatives directory out of the application's `tmp` directory. Other Hyrax-based applications may still use the default `{{ project_app_root }}/tmp/derivatives` directory, so it makes sense to leave that in for now.

# What are the changes?
See above.

# How should this be tested?

After building the `iawa` project, ensure that the new `{{ project_app_root }}/derivatives` directory exists.

# Additional Notes:
There will be an addition PR in the iawa project with the configuration change to point to the new non-tmp directory.

# Interested parties
@pmather @soumikgh 
