### PR TITLE
Add bundler version 1.x for VTechData

### DIFF
--- a/ansible/roles/ruby/tasks/main.yml
+++ b/ansible/roles/ruby/tasks/main.yml
@@ -20,7 +20,7 @@
     state: latest
     user_install: no
 
-- name: install bundler
+- name: install 1.x version of bundler
   gem:
     name: bundler
     version: '~> 1.17'

--- a/ansible/roles/ruby/tasks/main.yml
+++ b/ansible/roles/ruby/tasks/main.yml
@@ -19,3 +19,9 @@
     name: bundler
     state: latest
     user_install: no
+
+- name: install bundler
+  gem:
+    name: bundler
+    version: '~> 1.17'
+    user_install: no


### PR DESCRIPTION
**Add bundler gem version 1.x for VTechData**
* * *

**JIRA Ticket**: (https://webapps.es.vt.edu/jira/browse/LIBTD-1677) (:star:)

* Other Relevant Links (Meeting note, project page, related pull requests, etc.)

# What does this Pull Request do? (:star:)
Add additional bundler version to resolve error when running rails console

```
railsapps@data-repo:~/data-repo$ ./bin/rails c
Activating bundler (< 2) failed:
Could not find 'bundler' (< 2) - did find: [bundler-2.0.1]
Checked in 'GEM_PATH=/var/local/hydra/.gem/ruby/2.3.0:/var/lib/gems/2.3.0:/usr/lib/x86_64-linux-gnu/rubygems-integration/2.3.0:/usr/share/rubygems-integration/2.3.0:/usr/share/rubygems-integration/all', execute `gem env` for more information

To install the version of bundler this project requires, run gem install bundler -v '< 2'
```

# What's the changes? (:star:)
* Adds additional bundler gem
* bundler 2.x provides 'autoswitching' to use the version specified in lockfile.

# How should this be tested?
* build data-repo application using LIBTD-1677 branch of Installscripts
* ensure that data-repo functionality is unaffected
* ensure that Rails console can be started and works

# Additional Notes:
* branch `LIBTD-1677`

# Interested parties
@pmather 

(:star:) Required fields
