### PR TITLE
Refine handling of carousel image package

### DIFF
--- a/ansible/roles/hyrax/tasks/iawa.yml
+++ b/ansible/roles/hyrax/tasks/iawa.yml
@@ -42,10 +42,18 @@
     ignore_errors: True
     register: copy_carousel_image_package
 
+  - name: ensure carousel image directory exists
+    file:
+      path: '{{ project_app_root }}/app/assets/images/vtul/carousel'
+      owner: '{{ project_owner }}'
+      group: '{{ project_runner_group }}'
+      mode: "u=rwX,g=rX,o="
+      state: directory
+
   - name: untar carousel image asset dir
     unarchive:
       src: '{{ project_app_root }}/{{ carousel_pkg }}'
-      dest: '{{ project_app_root }}/app/assets/images/vtul/'
+      dest: '{{ project_app_root }}/app/assets/images/vtul/carousel/'
       owner: '{{ project_owner }}'
       group: '{{ project_runner_group }}'
       mode: "u=rwX,g=rX,o="

--- a/ansible/roles/hyrax/tasks/iawa.yml
+++ b/ansible/roles/hyrax/tasks/iawa.yml
@@ -48,7 +48,7 @@
       dest: '{{ project_app_root }}/app/assets/images/vtul/'
       owner: '{{ project_owner }}'
       group: '{{ project_runner_group }}'
-      mode: "u=rX,g=rX,o="
+      mode: "u=rwX,g=rX,o="
       remote_src: yes
     ignore_errors: True
     when: copy_carousel_image_package is successful


### PR DESCRIPTION
**Refine handling of carousel image package**
* * *

# What does this Pull Request do?

Previously, the user-supplied `carousel.tar.gz` file was expected to contain a top-level `carousel` directory under which the image directories resided.  This opens up the possibility of a user-supplied carousel package accidentally or maliciously overwriting content elsewhere in the `app/assets/images/vtul` directory hierarchy.

This change alters the semantics so as to remove the expectation of a top-level `carousel` directory in the package of carousel images.  Instead, it is expected to contain only the images and subdirectories related to the carousel, and these will be unarchived explicitly into the carousel directory during deployment.

In addition, the permissions are refined to allow redeployments of different carousel images without errors.  Previously, the lack of write permission for the application owner would result in an error on subsequent carousel image updates.

# What's the changes?

* Make the `carousel.tar.gz` package semantics such that the images are rooted at `./` in the carousel archive instead of `carousel/`;
* Correct a permissions problem affecting repeated unarchiving.

# How should this be tested?

* Deploy the IAWA `LIBTD-1655` branch using a locally-supplied `carousel.tar.gz` archive;
* Check the above deployment worked;
* Replace the `carousel.tar.gz` in `local_files/` with a `carousel.tar.gz` archive containing some different images;
* Redeploy via `vagrant provision`;
* Ensure the above re-provision completes without errors and the deployed application still works.

# Interested parties
@shabububu 