### PR TITLE
Set random password for "upload" user

### DIFF
--- a/ansible/roles/chroot-sftp/tasks/sftp_user.yml
+++ b/ansible/roles/chroot-sftp/tasks/sftp_user.yml
@@ -24,6 +24,7 @@
     name: "{{ sftp_user }}"
     group: "{{ sftp_chroot_group }}"
     shell: /usr/lib/openssh/sftp-server
+    password: "{{ lookup('password', '/dev/null length=23 encrypt=sha512_crypt') }}"
     state: present
 
 - name: ensure sftp upload user .ssh directory exists


### PR DESCRIPTION
**Set random password for "upload" user**
* * *

# What does this Pull Request do?
In some deployment environments the lack of a password being set for the `upload` user causes SFTP logins to be denied due to the account being considered locked.

This change sets a random password for the `upload` user.  This "unlocks" the account by setting a password but does not feasibly allow the password to be used for logins (or any other purpose that requires password authentication).  This does not affect pubkey authentication for SFTP.

# What's the changes?

Sets a random password for the `upload` user.

# How should this be tested?

Deploy the `geoblacklight` application and ensure a public key is specified to be allowed to log in for the `upload` user.  When the application is deployed, verify you can connect via SFTP as the `upload` user.  When connected, you should be able to list the upload area directories:
```
sftp> ls
Archive   Report    Upload
sftp>
```

# Additional Notes:
You can verify that a password has actually been set for the `upload` user by looking at `/etc/shadow`:
```
vagrant@geoblacklight:~$ sudo grep upload /etc/shadow
upload:$6$Qfcsn0pN$lUVclMWmuIpXvbtL9a7DZfCDkKOtfDBxe1K0tPGzmAL275CcJSOGsQ98yQG4FYpDBgZ/wZEarfmQVQsLDX47V1:17921:0:99999:7:::
vagrant@geoblacklight:~$
```

If a password has been set successfully then it will begin after `upload:` and be a string starting with `$6$`.  (Because the password is random, it will not match exactly the example above, but it will still begin with `$6$`.)
