### PR TITLE
Default to Ubuntu 18.04 for Vagrant

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -13,7 +13,7 @@
 # If no "--provider" is specified during "vagrant up" then the default
 # (VirtualBox) provider will be used.
 
-$vm_box = ENV['VAGRANT_VM_BOX'] || 'bento/ubuntu-16.04'
+$vm_box = ENV['VAGRANT_VM_BOX'] || 'bento/ubuntu-18.04'
 $secrets_items = {}
 begin
   require 'yaml'


### PR DESCRIPTION
**Default to Ubuntu 18.04 for Vagrant**
* * *

# What does this Pull Request do?

InstallScripts supports deploying to three versions of Ubuntu: 14.04, 16.04, and 18.04.  When deploying via Vagrant, the version to use can be set explicitly by setting the `VAGRANT_VM_BOX` environment variable to a supported Vagrant box prior to executing `vagrant up`.  If `VAGRANT_VM_BOX` is not set then a default is used.

This change switches the default to an Ubuntu 18.04 Vagrant box from the current Ubuntu 16.04 box that is used.

# What's the changes?

Henceforth, `vagrant up` will use the `bento/ubuntu-18.04` box by default.

# How should this be tested?

Deploy an InstallScripts application (e.g., `geoblacklight`) using Vagrant.  The application should deploy successfully into an Ubuntu 18.04 local VM.  You can verify the local VM is running Ubuntu 18.04 as follows after a successful `vagrant up` has completed:

1. `vagrant ssh`
2. `lsb_release -a`

The `lsb_release -a` command should return information indicating the VM OS is Ubuntu 18.04:
```
vagrant@geoblacklight:~$ lsb_release -a
No LSB modules are available.
Distributor ID:	Ubuntu
Description:	Ubuntu 18.04.1 LTS
Release:	18.04
Codename:	bionic
vagrant@geoblacklight:~$
```

# Additional Notes:
For completeness, after testing the default Ubuntu 18.04 deployment, you can `vagrant destroy --force` the VM and then deploy the same application in an Ubuntu 16.04 VM:

1. `vagrant destroy --force`
2. `export VAGRANT_VM_BOX=bento/ubuntu-16.04`
3. `vagrant up`
4. `vagrant ssh`
5. `lsb_release -a`

The output of `lsb_release -a` should indicate the VM OS is Ubuntu 16.04:
```
vagrant@geoblacklight:~$ lsb_release -a
No LSB modules are available.
Distributor ID:	Ubuntu
Description:	Ubuntu 16.04.5 LTS
Release:	16.04
Codename:	xenial
vagrant@geoblacklight:~$
```
# Interested parties
@VTUL/dld-dev 
