### PR TITLE
Precompile assets when necessary

### DIFF
--- a/ansible/roles/hyrax/tasks/iawa.yml
+++ b/ansible/roles/hyrax/tasks/iawa.yml
@@ -60,6 +60,8 @@
       remote_src: yes
     ignore_errors: True
     when: copy_carousel_image_package is successful
+    notify:
+      - precompile assets
   become: yes
   become_user: '{{ project_owner }}'
   environment:


### PR DESCRIPTION

**Precompile assets when carousel assets are supplied externally**
* * *

# What does this Pull Request do?
The IAWA local tasks are run after an initial flush of handlers.  This means for Rails `production` mode that the `assets:precompile` task will have been run already.  If an external carousel image package is supplied and unpacked, this will mean new image assets have been added.  For Rails `production` mode, this means we should run the `assets:precompile` task again via the `precompile assets` handler.

This change invokes the `precompile assets` handler if content is unarchived from a carousel image package.

# What's the changes?
The `precompile assets` is invoked if carousel images are unarchived.  Note that the actual handler is itself conditional on `when: project_app_env == 'production'`, so it will only actually do anything when the Rails environment is set to `production`.

# How should this be tested?

Deploy the `LIBTD-1655` branch of IAWA.  When supplying an external image `carousel.tar.gz`, verify that the carousel images are displayed correctly.

# Additional Notes:

For `production` mode, you should see something like the following near the end of the Ansible playbook run:
```
TASK [hyrax : untar carousel image asset dir] **********************************
changed: [app]

TASK [hyrax : upgrade users] ***************************************************
changed: [app]

TASK [hyrax : add initial controlled vocabularies] *****************************
changed: [app]

RUNNING HANDLER [passenger : restart nginx] ************************************
changed: [app]

RUNNING HANDLER [hyrax : precompile assets] ************************************
changed: [app]
```

In other words, when you see:
```
TASK [hyrax : untar carousel image asset dir] **********************************
changed: [app]
```
you should see a subsequent:
```
RUNNING HANDLER [hyrax : precompile assets] ************************************
changed: [app]
```
indicating that the assets have been precompiled.

Note that the `precompile assets` handler is only invoked if the `hyrax : untar carousel image asset dir` task actually unarchives something (i.e., the `unarchive` module task status is `changed`).

Also note that for Rails `development` mode the handler will be invoked but skipped:
```
RUNNING HANDLER [hyrax : precompile assets] ************************************
skipping: [app]
```
because asset precompilation only applies to `production` mode.

# Interested parties
@tingtingjh, @shabububu 