### PR TITLE
Wire down uid/gid for users

### DIFF
--- a/ansible/example_site_secrets.yml
+++ b/ansible/example_site_secrets.yml
@@ -18,14 +18,23 @@ project_secret_key_base: ''
 #
 # Name of the user who owns/edits the application
 project_owner: 'hydra'
+# The numeric uid of {{ project_owner }}
+project_owner_uid: 60001
 # Name of group to which {{ project_owner }} belongs
 project_owner_group: '{{ project_owner }}'
+# The numeric gid of {{ project_owner_group }}
+project_owner_gid: 60001
 # The home directory of {{ project_owner }}
 project_owner_home: '/var/local/{{ project_owner }}'
 # Name of the user running the application (should be different from project_owner)
 project_runner: 'railsapps'
+# The numeric uid of {{ project_runner }}
+project_runner_uid: 60002
 # Primary group to which {{ project_runner }} belongs
 project_runner_group: '{{ project_runner }}'
+# The numeric gid of {{ project_runner_group }}
+project_runner_gid: 60002
+
 
 # Graylog logging
 #
@@ -148,8 +157,12 @@ project_app_root: '{{ project_owner_home }}/{{ project_name }}'
 sftp_user: "upload"
 # Username that should be the primary owner of the chroot SFTP directory area
 sftp_chroot_owner: "{{ project_runner }}"
+# Numeric id of {{ sftp_chroot_owner }}
+sftp_chroot_uid: "{{ project_runner_uid }}"
 # Group name that should be the group owner of the chroot SFTP directory area
 sftp_chroot_group: "{{ sftp_user }}"
+# Numeric group id of {{ sftp_chroot_owner }}
+sftp_chroot_gid: "{{ sftp_user_gid }}"
 # Home directory of {{ sftp_user }}.  This is normally separate from
 # {{ sftp_upload_root }} and primarily serves as a place to put authorized_keys
 sftp_home_dir: "/home/{{ sftp_user }}"

--- a/ansible/roles/chroot-sftp/README.md
+++ b/ansible/roles/chroot-sftp/README.md
@@ -13,8 +13,13 @@ Role Variables
 
 Role variables are listed below:
 
-- `sftp_user`: The username of the chroot SFTP upload area.
+- `sftp_user`: The username of the chroot SFTP upload user.
+- `sftp_group`: The group name of the chroot SFTP upload user.
+- `sftp_user_uid`: The numeric user id of the chroot SFTP upload user.
+- `sftp_user_gid`: The numeric group id of the chroot SFTP upload user.
 - `sftp_chroot_owner`: The username of the user that owns the chroot SFTP area directory hierarchy directories.
+- `sftp_chroot_uid`: The numeric user id of the user that owns the chroot SFTP area directory hierarchy directories.
 - `sftp_chroot_group`: The group name to be used for the chroot SFTP area directory hierarchy directories.
+- `sftp_chroot_gid`: The numeric group id of the user that owns the chroot SFTP area directory hierarchy directories.
 - `sftp_home_dir`: The home directory of the chroot SFTP upload user (separate from the chroot directory).
 - `sftp_upload_root`: The root directory of the chroot SFTP upload area.

--- a/ansible/roles/chroot-sftp/defaults/main.yml
+++ b/ansible/roles/chroot-sftp/defaults/main.yml
@@ -1,6 +1,11 @@
 ---
 sftp_user: "upload"
+sftp_group: "upload"
+sftp_user_uid: 60000
+sftp_user_gid: 60000
 sftp_chroot_owner: "{{ sftp_user }}"
+sftp_chroot_uid: "{{ sftp_user_uid }}"
 sftp_chroot_group: "{{ sftp_user }}"
+sftp_chroot_gid: "{{ sftp_user_gid }}"
 sftp_home_dir: "/home/{{ sftp_user }}"
 sftp_upload_root: "/opt/sftp/chroot"

--- a/ansible/roles/chroot-sftp/tasks/sftp_chroot.yml
+++ b/ansible/roles/chroot-sftp/tasks/sftp_chroot.yml
@@ -9,6 +9,7 @@
   file:
     path: "{{ sftp_upload_root }}"
     owner: root
+    group: root
     mode: "0755"
     state: directory
 

--- a/ansible/roles/chroot-sftp/tasks/sftp_user.yml
+++ b/ansible/roles/chroot-sftp/tasks/sftp_user.yml
@@ -3,17 +3,20 @@
   file:
     path: "{{ sftp_home_dir }}"
     owner: root
+    group: root
     mode: "0711"
     state: directory
 
 - name: ensure sftp chroot owner exists
   user:
     name: "{{ sftp_chroot_owner }}"
+    uid: "{{ sftp_chroot_uid }}"
     state: present
 
 - name: ensure sftp chroot group exists
   group:
     name: "{{ sftp_chroot_group }}"
+    gid: "{{ sftp_chroot_gid }}"
     state: present
 
 - name: ensure sftp user exists and is a member of sftp chroot group
@@ -22,6 +25,7 @@
     createhome: false
     home: "{{ sftp_home_dir }}"
     name: "{{ sftp_user }}"
+    uid: "{{ sftp_user_uid }}"
     group: "{{ sftp_chroot_group }}"
     shell: /usr/lib/openssh/sftp-server
     password: "{{ lookup('password', '/dev/null length=23 encrypt=sha512_crypt') }}"
@@ -29,8 +33,9 @@
 
 - name: ensure sftp upload user .ssh directory exists
   file:
-    path: "{{ sftp_home_dir}}/.ssh"
+    path: "{{ sftp_home_dir }}/.ssh"
     owner: "{{ sftp_user }}"
+    group: "{{ sftp_group }}"
     mode: "0500"
     state: directory
 

--- a/ansible/roles/project_user/README.md
+++ b/ansible/roles/project_user/README.md
@@ -3,7 +3,7 @@ Project User
 
 Creates the project users and groups. There are two project users: one that owns the files (`project_owner`) and another under which the application runs (`project_runner`). These have corresponding groups, `project_owner_group` and `project_runner_group` respectively. The users and groups are defined in `site_secrets.yml`.
 
-If the project user groups should be system (low-numbered) groups then `project_owner_group_system` and `project_runner_group_system` should be set to `true` appropriately. Similarly, if a specific numeric group id should be used, it should be set in `project_owner_group_id` or `project_runner_group_id` as appropriate.
+If the project user groups should be system (low-numbered) groups then `project_owner_group_system` and `project_runner_group_system` should be set to `true` appropriately. Similarly, if a specific numeric group id should be used, it should be set in `project_owner_gid` or `project_runner_gid` as appropriate. Finally, the numeric id of the `project_owner` and `project_runner` user is specified in the `project_owner_uid` and `project_runner_uid` variables respectively.
 
 Requirements
 ------------
@@ -15,9 +15,13 @@ Role Variables
 
 Role variables are listed below, along with their defaults:
 
+    project_owner: 'hydra'
+    project_owner_uid: 60001
+    project_owner_gid: 60001
+    project_runner: 'railsapps'
+    project_runner_uid: 60002
+    project_runner_gid: 60002
     project_owner_group_system: false
-    project_owner_group_id: <Not Defined>
     project_runner_group_system: false
-    project_runner_group_id: <Not Defined>
 
 The group gid is omitted unless the variable is defined.

--- a/ansible/roles/project_user/defaults/main.yml
+++ b/ansible/roles/project_user/defaults/main.yml
@@ -3,7 +3,15 @@
 project_owner_group_system: 'false'
 # Whether {{ project_runner_group }} is a system (lower-numbered gid) group
 project_runner_group_system: 'false'
+# Name of the user who owns/edits the application
+project_owner: 'hydra'
+# The numeric uid of {{ project_owner }}
+project_owner_uid: 60001
 # The numeric gid of {{ project_owner_group }}
-#project_owner_group_id: ''
+project_owner_gid: 60001
+# Name of the user running the application (should be different from project_owner)
+project_runner: 'railsapps'
+# The numeric uid of {{ project_runner }}
+project_runner_uid: 60002
 # The numeric gid of {{ project_runner_group }}
-#project_runner_group_id: ''
+project_runner_gid: 60002

--- a/ansible/roles/project_user/tasks/main.yml
+++ b/ansible/roles/project_user/tasks/main.yml
@@ -3,12 +3,13 @@
   group:
     name: '{{ project_runner_group }}'
     system: '{{ project_runner_group_system }}'
-    gid: '{{ project_runner_group_id | default(omit) }}'
+    gid: '{{ project_runner_gid | default(omit) }}'
     state: present
 
 - name: create the user under which the application will run
   user:
     name: '{{ project_runner }}'
+    uid: '{{ project_runner_uid | default(omit) }}'
     group: '{{ project_runner_group }}'
     comment: '{{ project_name }} runtime user'
     home: '{{ project_owner_home }}'
@@ -19,12 +20,13 @@
   group:
     name: '{{ project_owner_group }}'
     system: '{{ project_owner_group_system }}'
-    gid: '{{ project_owner_group_id | default(omit) }}'
+    gid: '{{ project_owner_gid | default(omit) }}'
     state: present
 
 - name: create the project user with no login password
   user:
     name: '{{ project_owner }}'
+    uid: '{{ project_owner_uid | default(omit) }}'
     group: '{{ project_owner_group }}'
     groups: '{{ project_runner_group }}'
     home: '{{ project_owner_home }}'


### PR DESCRIPTION
**Wire down uid/gid for users**
* * *

# What does this Pull Request do?

InstallScripts adds several users to the system during deployment: two for Rails applications and one as an SFTP uploader (for `geoblacklight`).  Currently, only the user and group names are specified when creating these users.  The actual uid and gid used is auto-assigned by the system so as not to conflict with existing users.  If users have been created on the OS outside InstallScripts then this makes the actual uid and gid settings of the InstallScripts users unpredictable.  This, in turn makes it difficult to align uid and gid assignment for, e.g., NFS mounts or other situations where uid and gid settings must match precisely.

This change allows uid and gid to be specified precisely for InstallScripts-added users.  (Note, this does not apply to users created by installed packages, e.g., Solr, Tomcat, etc., which manage their own associated users.)  The defaults for uid and gid start at 60000, which lies outside the range of system auto-assigned uid and gid, so as not to conflict.

The settings in `example_site_secrets.yml` have been updated to values that will work correctly for all currently-supported InstallScripts applications.

# What's the changes?

* Adds variables to specify uid and gid settings for `project_owner`, `project_runner`, and `sftp_user` users created and managed by InstallScripts
* Updates `example_site_secrets.yml` with working values for uid and gid

# How should this be tested?

* Deploy an InstallScripts-supported application
* Check it works

# Additional Notes:

* Testing the `geoblacklight` application will test all InstallScripts-managed users
* Ansible Tower templates will have to be updated to add these extra settings