### PR TITLE
Make ubuntu/bionic64 default Vagrant box

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -13,7 +13,7 @@
 # If no "--provider" is specified during "vagrant up" then the default
 # (VirtualBox) provider will be used.
 
-$vm_box = ENV['VAGRANT_VM_BOX'] || 'bento/ubuntu-18.04'
+$vm_box = ENV['VAGRANT_VM_BOX'] || 'ubuntu/bionic64'
 $secrets_items = {}
 begin
   require 'yaml'
@@ -101,7 +101,8 @@ Vagrant.configure("2") do |config|
   config.vm.provision vagrant_ansible_provisioner() do |ansible|
     ansible.playbook = "ansible/#{site_file()}_site.yml"
     ansible.extra_vars = 'ansible/site_secrets.yml'
-    if box_name_to_ubuntu_release( $vm_box )[0] == :xenial
+    os_release = box_name_to_ubuntu_release( $vm_box )[0]
+    if os_release == :xenial or os_release == :bionic
       ansible.host_vars = {
         :app => {'ansible_python_interpreter' => '/usr/bin/python3'}
       }

--- a/ansible/roles/common/vars/ubuntu-18.yml
+++ b/ansible/roles/common/vars/ubuntu-18.yml
@@ -3,4 +3,4 @@ common_essential_packages:
   - acl
   - build-essential
   - apt-transport-https
-  - python-apt
+  - python3-apt

--- a/ansible/roles/postgresql/vars/ubuntu-18.yml
+++ b/ansible/roles/postgresql/vars/ubuntu-18.yml
@@ -1,4 +1,4 @@
 ---
 postgresql_client_packages:
   - libpq-dev
-  - python-psycopg2
+  - python3-psycopg2


### PR DESCRIPTION
**Make ubuntu/bionic64 default Vagrant box**
* * *

# What does this Pull Request do?
Change the default Vagrant box used because the official Ubuntu Vagrant boxes align better with the OS install on our Ansible Tower VMs.

We also correct some Python package installs to ensure the Python 3 versions are used, to avoid inadvertently pulling in a minimal Python 2.x as a dependency.

# What's the changes?

* Changes default `VAGRANT_VM_BOX` to `ubuntu/bionic64`
* Makes sure Ubuntu Bionic-flavoured OSes use `/usr/bin/python3` for `ansible_python_interpreter`
* Uses Python 3 dependent packages on Ubuntu Bionic-flavoured OSes

# How should this be tested?

* Deploy a known-working InstallScripts application using a Vagrant local deployment
* After deployment is completed, connect to the local VM using `vagrant ssh`
* Make sure Python 2 has not been installed:
```
vagrant@iawa:~$ python --version

Command 'python' not found, but can be installed with:

apt install python3
apt install python
apt install python-minimal

Ask your administrator to install one of them.

You also have python3 installed, you can run 'python3' instead.

vagrant@iawa:~$ python3 --version
Python 3.6.7
vagrant@iawa:~$
```