### PR TITLE
Add support for smart relay host

### DIFF
--- a/ansible/example_site_secrets.yml
+++ b/ansible/example_site_secrets.yml
@@ -174,7 +174,9 @@ sftp_upload_root: "/opt/sftp/geodata"
 # Fetch local_files from remote URL
 # Remote archive URL - remote archive fetched only if this variable is set
 # local_files_archive: 'https://hydrafiles.lib.vt.edu/{{ project_name }}/local_files.zip'
-#
+# Uncomment and assign appropriately the setting below to define a smart mail
+# host to which all mail should be relayed.
+#mail_relayhost: mailrelay.smtp.vt.edu 
 # Variables related to direct Ansible invocation:
 # ansible_user: 'superuser'
 

--- a/ansible/roles/postfix/README.md
+++ b/ansible/roles/postfix/README.md
@@ -16,3 +16,8 @@ Role Variables
 Role variables are listed below, along with their defaults:
 
     postfix_inet_interfaces: loopback-only
+    mail_relayhost: <undefined>
+
+If `mail_relayhost` is defined then Postfix is configured to route all mail
+via that hostname/IP.  If `mail_relayhost` is undefined then the `relayhost`
+setting is removed from the Postfix configuration file.

--- a/ansible/roles/postfix/tasks/main.yml
+++ b/ansible/roles/postfix/tasks/main.yml
@@ -20,7 +20,25 @@
 
 - name: set postfix listening interfaces
   lineinfile:
-    dest: /etc/postfix/main.cf
-    regexp: '^inet_interfaces = .*$'
+    path: /etc/postfix/main.cf
+    regexp: '^inet_interfaces\s*=.*$'
     line: 'inet_interfaces = {{ postfix_inet_interfaces }}'
+    state: present
   notify: restart postfix
+
+- name: set smart host mail relay if defined
+  lineinfile:
+      path: /etc/postfix/main.cf
+      regexp: '^relayhost\s*=.*$'
+      line: 'relayhost = [{{ mail_relayhost|default("") }}]'
+      state: present
+  notify: restart postfix
+  when: mail_relayhost is defined
+
+- name: remove smart host mail relay if not defined
+  lineinfile:
+      path: /etc/postfix/main.cf
+      regexp: '^relayhost\s*=.*$'
+      state: absent
+  notify: restart postfix
+  when: mail_relayhost is not defined


### PR DESCRIPTION
**Add support for smart relay host**
* * *

# What does this Pull Request do?
Amends the `postfix` role to allow a smart relay host to be defined. The variable `mail_relayhost`, if defined, is used to define the Postfix `relayhost` parameter. If `mail_relayhost` is not defined then any
definition of `relayhost` is removed from the Postfix configuration (and Postfix sends e-mail directly instead of via a smart host).

# What's the changes?
Sets or removes the Postfix `relayhost` setting from its `main.cf` file depending upon whether
`mail_relayhost` is defined.

# How should this be tested?

1. Deploy the `VTUL/data-repo` application using this branch.  A `grep relayhost /etc/postfix/main.cf` inside the resultant VM after `vagrant up` should not return any results.
2. Next, do a `vagrant provision` of the application but with the `mail_relayhost: mailrelay.smtp.vt.edu` line from `site_secrets.yml` uncommented this time. Now,  `grep relayhost /etc/postfix/main.cf` should return a line with `relayhost = [mailrelay.smtp.vt.edu]`.

# Interested parties
@soumikgh 

