### PR TITLE
Add static IIIF image server base URL to be passed into the IAWA application.

### DIFF
--- a/ansible/example_site_secrets.yml
+++ b/ansible/example_site_secrets.yml
@@ -185,3 +185,6 @@ batch_import_basepath: "{{ project_app_root }}/tmp/imports"
 
 # Carousel package (for IAWA)
 carousel_pkg: 'carousel.tar.gz'
+
+# AWS S3 IIIF image server base URL
+iiif_manifest_base_url: "https://s3.amazonaws.com/scholar-jekyll.dev.vtlibcloud.com/iiif_s3_test/"

--- a/ansible/roles/hyrax/templates/secrets.yml.j2
+++ b/ansible/roles/hyrax/templates/secrets.yml.j2
@@ -60,6 +60,7 @@ default: &default
     site_key: {{project_recaptcha_site_key}}
     secret_key: {{project_recaptcha_secret_key}}
   batch_import_basepath: {{ batch_import_basepath }}
+  iiif_manifest_base_url: {{ iiif_manifest_base_url }}
 
 # These are the settings applicable for RAILS_ENV=development.  They inherit
 # settings from the above "default".


### PR DESCRIPTION
**JIRA Ticket**: (https://webapps.es.vt.edu/jira/browse/LIBTD-1786) (:star:)

* Other Relevant Links (https://webapps.es.vt.edu/jira/browse/LIBTD-1785)

# What does this Pull Request do? (:star:)
This PR adds iiif_manifest_base_url to the secrets.yml for the IAWA application. The IAWA application can then use the base url to generate the static AWS S3 iiif manifest URL associated with each item so that it can be used by Mirador viewer to display the images within the item.

# How should this be tested?

* This PR is tested in branch LIBTD-1786
* Change corresponding local ansible/site_secrets.yml to reflect the change in ansible/example_site_secrets.yml
* Run InstallScripts to create the IAWA project. 
* Ensure that the generated secrets.yml file contains the iiif_manifest_base_url information. 
* For testing purpose, set iiif_image_base_url: "https://s3.amazonaws.com/scholar-jekyll.dev.vtlibcloud.com/iiif_s3_test/Ms1990_057_Chadeayne/Edited/Ms1990_057_Box1/"

# Interested parties
Tag (@yinlinchen @pmather) interested parties

(:star:) Required fields
