### PR TITLE
Improve switching of Ruby version

### DIFF
--- a/ansible/roles/geoblacklight/tasks/main.yml
+++ b/ansible/roles/geoblacklight/tasks/main.yml
@@ -13,3 +13,8 @@
 - include: geoblacklight_setup.yml
 - include: solr_setup.yml
 - include: cron.yml
+
+- name: restart ruby applications when ruby version changed
+  command: /bin/true
+  notify: restart nginx
+  when: ruby_version_changed | default( False )

--- a/ansible/roles/hyrax/tasks/main.yml
+++ b/ansible/roles/hyrax/tasks/main.yml
@@ -158,6 +158,9 @@
     clean: yes
     exclude_groups: ''
   when: project_app_env != 'production'
+  notify:
+    - restart nginx
+    - restart sidekiq workers
   become: yes
   become_user: '{{ project_owner }}'
 
@@ -171,6 +174,9 @@
     clean: yes
     exclude_groups: 'development test'
   when: project_app_env == 'production'
+  notify:
+    - restart nginx
+    - restart sidekiq workers
   become: yes
   become_user: '{{ project_owner }}'
 
@@ -239,6 +245,13 @@
   when: project_app_env == 'production'
   notify:
     - precompile assets
+
+- name: restart ruby applications when ruby version changed
+  command: /bin/true
+  notify:
+    - restart nginx
+    - restart sidekiq workers
+  when: ruby_version_changed | default( False )
 
 - name: execute pending handlers for rake tasks to work
   meta: flush_handlers

--- a/ansible/roles/ruby/tasks/main.yml
+++ b/ansible/roles/ruby/tasks/main.yml
@@ -10,9 +10,26 @@
     name:
       - ruby{{ ruby_version | default('2.3') }}
       - ruby{{ ruby_version | default('2.3') }}-dev
+      - ruby-switch
     state: present
     cache_valid_time: '{{ apt_cache_timeout }}'
     update_cache: yes
+
+- name: determine existing default ruby version
+  command: ruby --version
+  register: existing_ruby_version
+
+- name: make selected ruby version explicitly the default
+  command: ruby-switch --set ruby{{ ruby_version | default('2.3') }}
+
+- name: determine new default ruby version
+  command: ruby --version
+  register: new_ruby_version
+
+- name: work out whether the default ruby has changed
+  set_fact:
+    ruby_version_changed: true
+  when: existing_ruby_version.stdout != new_ruby_version.stdout
 
 - name: install bundler
   gem:

--- a/ansible/roles/sufia/tasks/main.yml
+++ b/ansible/roles/sufia/tasks/main.yml
@@ -214,6 +214,13 @@
   notify:
     - precompile assets
 
+- name: restart ruby applications when ruby version changed
+  command: /bin/true
+  notify:
+    - restart nginx
+    - restart resque
+  when: ruby_version_changed | default( False )
+
 - name: execute pending handlers for rake tasks to work
   meta: flush_handlers
   when: project_tasks.stat.exists


### PR DESCRIPTION
**Improve switching of Ruby version**
* * *

# What does this Pull Request do?

The repository from which we install Ruby supports multiple versions. We
allow the version to be selected by setting the `ruby_version` variable.
Unfortunately, changing the value of `ruby_version` does not mean the
new version of Ruby is used. This change fixes that behaviour, ensuring
explicitly that the version of Ruby selected will be used by the relevant
running Ruby applications.

# What's the changes?

The `ruby-switch` utility is used with the packaged versions of Ruby to
determine which version of Ruby installed will be the default system
Ruby. Previously, whichever version of Ruby was installed first would
become the version of Ruby used from there on. Using `ruby-switch`
after installing (or changing) Ruby versions ensures the latest
installed version will be used as default.

In addition, when the version of Ruby is switched, we need explicitly to
restart any running Ruby-based daemons/services. This change introduces
an explicit test of whether the current version of Ruby being deployed
changes from that which was already deployed. If this is the case, a new
fact is set that may be tested in other Ruby-consuming roles to know
whether or not to restart long-running daemons or services that use Ruby
installed by these playbooks.

# How should this be tested?

Deploy a supported application. This will use the default Ruby version 2.3. Then, edit `site_secrets.yml` and append the line `ruby_version: "2.4"`. Redeploy the application (e.g., `vagrant provision`). This will change the version of Ruby to 2.4.

# Additional Notes:

You can use `ruby --version` to identify the default version of Ruby that is used.  This should be 2.3.x after the first deployment and 2.4.x after the second.

# Interested parties
@soumikgh 