### PR TITLE
Ensure local files are unpacked for "fedora4" role

### DIFF
--- a/ansible/roles/fedora4/README.md
+++ b/ansible/roles/fedora4/README.md
@@ -6,7 +6,9 @@ Creates the Fedora4 user and group, and installs Fedora 4.
 Requirements
 ------------
 
-Tomcat must be installed.  This role references variables from the `tomcat` role.
+Tomcat must be installed.  This role references variables from the `tomcat` role.  In addition, the `local_files` role must be installed
+due to the option of installing a locally-provided Fedora WAR file.
+This ensures any local files are present before executing this role.
 
 Role Variables
 --------------

--- a/ansible/roles/fedora4/meta/main.yml
+++ b/ansible/roles/fedora4/meta/main.yml
@@ -1,3 +1,4 @@
 ---
 dependencies:
   - { role: tomcat }
+  - { role: local_files }


### PR DESCRIPTION
**Ensure local files are unpacked for `fedora4` role**
* * *

# What does this Pull Request do?

Now that the `fedora4` role has the possibility of using a locally-supplied
Fedora WAR file we need to ensure that these local files are present
before the `fedora4` role tasks are executed. This is especially true in
the case where local files are supplied via a `local_files_archive` archive.

This change corrects this omission by making the `local_files` role
a dependency of the `fedora4`.

# What's the changes?

Adds the `local_files` role as a dependency of the `fedora4` role.
