### PR TITLE
Ensure latest Brightbox PPA Ruby version is used

### DIFF
--- a/ansible/roles/ruby/tasks/main.yml
+++ b/ansible/roles/ruby/tasks/main.yml
@@ -11,7 +11,7 @@
       - ruby{{ ruby_version | default('2.3') }}
       - ruby{{ ruby_version | default('2.3') }}-dev
       - ruby-switch
-    state: present
+    state: latest
     cache_valid_time: '{{ apt_cache_timeout }}'
     update_cache: yes
 


### PR DESCRIPTION


**Ensure latest Brightbox PPA Ruby version is used**
* * *

# What does this Pull Request do?

The Brightbox PPA provides many different packaged versions of Ruby.
Ubuntu 18.04 (Bionic) comes with its own version of Ruby 2.5. This
creates a problem when attempting to use Ruby 2.5 from the Brightbox
PPA when using the "ruby" role in InstallScripts (e.g., by setting
"ruby_version" to "2.5" in "site_secrets.yml"). Because there is already
a "ruby2.5" package installed, the "install Brightbox Ruby package" play
invoking the "apt" module does not install "ruby2.5" from the Brightbox
PPA just added. This causes the subsequent "ruby-switch" command
to set the default to fail with the complaint that there are no
alternatives available.

This change instructs the "apt" play to install the latest versions of
the Ruby packages. This has the effect of installing all of the versions
from the Brightbox PPA.

# What's the changes?

Forces "latest" to be used when installing the Ruby packages, thereby ensuring the Brightbox PPA versions are installed.

# How should this be tested?

This problem currently only affects trying to use `ruby_version: '2.5'` on Ubuntu 18.04 (Bionic) in our environment.  To test, deploy the `iawa` application with `ruby_version: '2.5'` appended to the bottom of the `site_secrets.yml` file.  (Make sure this is a fresh deployment, as the problem only affects that particular edge case.)

After successful deployment, connect to VM via `vagrant ssh` and use `ruby-switch` to verify that Ruby 2.5 is being used and that the Brightbox package is installed, e.g.:

```
vagrant@iawa:~$ ruby-switch --check
Currently using: ruby2.5
------------------------

ruby	-> /usr/bin/ruby2.5
gem	-> /usr/bin/gem2.5
vagrant@iawa:~$ ruby-switch --list
ruby2.5
vagrant@iawa:~$ ruby --version
ruby 2.5.5p157 (2019-03-15 revision 67260) [x86_64-linux-gnu]
vagrant@iawa:~$ ruby2.5 --version
ruby 2.5.5p157 (2019-03-15 revision 67260) [x86_64-linux-gnu]
vagrant@iawa:~$ apt list ruby2.5
Listing... Done
ruby2.5/bionic,now 2.5.5-1bbox1~bionic1 amd64 [installed]
```

(The `bbox` in the package name indicates it's the Brightbox packaged version.)

# Interested parties
@tingtingjh 
