### PR TITLE
Various deprecation removals and improvements

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -94,7 +94,7 @@ Vagrant.configure("2") do |config|
     config.hostmanager.enabled = true
     config.hostmanager.manage_host = true
     config.hostmanager.ignore_private_ip = false
-    config.hostmanager.include_offline = true
+    config.hostmanager.include_offline = false
   end
 
   # Ansible provisioner default settings

--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -18,7 +18,7 @@
     autoclean: yes
     update_cache: yes
     cache_valid_time: '{{ apt_cache_timeout }}'
-  when: perform_dist_upgrade
+  when: perform_dist_upgrade|bool
 
 - name: install building software and build essentials
   apt:

--- a/ansible/roles/fits/tasks/main.yml
+++ b/ansible/roles/fits/tasks/main.yml
@@ -28,7 +28,9 @@
     src: /tmp/fits-{{ fits_version }}.zip
     dest: '{{ local_files_dir }}/'
     flat: True
-  when: ansible_virtualization_type == 'virtualbox'
+  when:
+    - cached_fits is failed
+    - ansible_virtualization_type == 'virtualbox'
 
 - name: unarchive fits distribution
   unarchive:

--- a/ansible/roles/hyrax/tasks/postgres_setup.yml
+++ b/ansible/roles/hyrax/tasks/postgres_setup.yml
@@ -4,7 +4,7 @@
     name: '{{ project_db_user }}'
     password: '{{ project_db_password }}'
     role_attr_flags: CREATEDB
-  when: postgresql_is_local
+  when: postgresql_is_local|bool
 
 - name: create project database role on remote postgresql server
   postgresql_user:
@@ -21,7 +21,7 @@
     name: '{{ project_db_name }}'
     encoding: 'UTF-8'
     owner: '{{ project_db_user }}'
-  when: postgresql_is_local
+  when: postgresql_is_local|bool
 
 - name: create project database on remote postgresql server
   postgresql_db:

--- a/ansible/roles/phantomjs/tasks/main.yml
+++ b/ansible/roles/phantomjs/tasks/main.yml
@@ -33,4 +33,6 @@
     src: /tmp/{{ phantomjs_src }}
     dest: '{{ local_files_dir }}/'
     flat: True
-  when: ansible_virtualization_type == 'virtualbox'
+  when:
+    - cached_pjs is failed
+    - ansible_virtualization_type == 'virtualbox'

--- a/ansible/roles/postgresql/handlers/main.yml
+++ b/ansible/roles/postgresql/handlers/main.yml
@@ -4,4 +4,4 @@
     name: postgresql
     state: restarted
   become: yes
-  when: postgres_is_local
+  when: postgres_is_local|bool

--- a/ansible/roles/postgresql/tasks/main.yml
+++ b/ansible/roles/postgresql/tasks/main.yml
@@ -29,7 +29,7 @@
     state: present
     cache_valid_time: '{{ apt_cache_timeout }}'
     update_cache: yes
-  when: postgresql_is_local
+  when: postgresql_is_local|bool
 
 - name: install postgresql client packages
   apt:
@@ -45,13 +45,13 @@
     group: '{{ database_group }}'
     owner: '{{ database_user }}'
   register: configure_postgres
-  when: postgresql_is_local
+  when: postgresql_is_local|bool
 
 - name: ensure postgres starts on boot
   service:
     name: postgresql
     enabled: yes
-  when: postgresql_is_local
+  when: postgresql_is_local|bool
 
 - name: restart postgres server
   service:

--- a/ansible/roles/sufia/tasks/postgres_setup.yml
+++ b/ansible/roles/sufia/tasks/postgres_setup.yml
@@ -4,7 +4,7 @@
     name: '{{ project_db_user }}'
     password: '{{ project_db_password }}'
     role_attr_flags: CREATEDB
-  when: postgresql_is_local
+  when: postgresql_is_local|bool
 
 - name: create project database role on remote postgresql server
   postgresql_user:
@@ -21,7 +21,7 @@
     name: '{{ project_db_name }}'
     encoding: 'UTF-8'
     owner: '{{ project_db_user }}'
-  when: postgresql_is_local
+  when: postgresql_is_local|bool
 
 - name: create project database on remote postgresql server
   postgresql_db:


### PR DESCRIPTION

**Various deprecation removals and improvements**
* * *

# What does this Pull Request do?

These changes are a potpourri of fixes to address deprecation warnings
and introduce quality-of-life improvements for developers. Changes
include the following:

- Ansible 2.8 issues a deprecation warning regarding using a "bare"
variable in a True/False context (e.g., `when: somevar`). This quietens
such deprecations by explicitly casting such variables using the `|bool`
filter.
- Changes the `hostmanager.include_offline` setting for the Vagrant
hostmanager plugin to keep track of only active VMs. This is to attempt
to remedy `/etc/hosts` from growing out of control.
- The "local caching" feature of the `fits` and `phantomjs` roles would
unconditionally copy ("cache") the FITS/PhantomJS distribution back to
the local Ansible control host (i.e., into `ansible/local_files`)
whether or not anything had been downloaded remotely and should be
cached locally for the future. This change only copies back the FITS/
PhantomJS distribution downloaded if a local cached copy was not used.
This eliminates the time spent copying the relevant distribution back
from the system/VM being provisioned when it is unnecessary.

# What's the changes?

See above.

# How should this be tested?

Deploy one of the Fedora/Samvera applications (e.g., `data-repo` or `iawa`).  Be sure to set `project_app_env` to `development` in `site_secrets.yml` as the `phantomjs` role is only used in `development` mode.

On the initial `vagrant up`, the FITS and PhantomJS distributions will not be cached in `local_files` and so will be downloaded remotely and then copied locally.

Then, perform a `vagrant provision` to re-provision the VM.  This time, the distributions should not be downloaded and should not be copied back to the local machine.  E.g., in the case of FITS, you should see something like this:
```
TASK [fits : download fits distribution to /tmp] *******************************
skipping: [app]

TASK [fits : cache fits for the future] ****************************************
skipping: [app]
```

This indicates (because of the `skipping`) that FITS was not downloaded from the remote distribution site nor was it copied back to the local machine.

You should also not see any Ansible deprecation warnings.

# Interested parties
@tingtingjh 