### PR TITLE
make tmp/cache writable and delete bootsnap cache to fix error

### DIFF
--- a/ansible/roles/geoblacklight/tasks/geoblacklight_setup.yml
+++ b/ansible/roles/geoblacklight/tasks/geoblacklight_setup.yml
@@ -38,6 +38,8 @@
   with_items:
     - path: "{{ project_app_root }}/tmp"
       mode: "0777"
+    - path: "{{ project_app_root }}/tmp/cache"
+      mode: "0777"
     - path: "{{ project_app_root }}/log"
       mode: "0770"
     - path: "{{ project_app_root }}/db"

--- a/ansible/roles/geoblacklight/tasks/main.yml
+++ b/ansible/roles/geoblacklight/tasks/main.yml
@@ -18,3 +18,11 @@
   command: /bin/true
   notify: restart nginx
   when: ruby_version_changed | default( False )
+
+- name: remove Bootsnap load path cache
+  command: rm -r {{ project_app_root }}/tmp/cache/bootsnap-load-path-cache
+  ignore_errors: True
+
+- name: remove Bootsnap compile cache
+  command: rm -r {{ project_app_root }}/tmp/cache/bootsnap-compile-cache
+  ignore_errors: True


### PR DESCRIPTION
**Make tmp/cache writable and delete bootsnap cache to fix error.**
* * *

**JIRA Ticket**: (https://webapps.es.vt.edu/jira/browse/LIBTD-1890) (:star:)

# What does this Pull Request do? (:star:)
Newest version of Geoblacklight leverages the bootsnap gem (https://github.com/Shopify/bootsnap) to speed up the application. This gem needs to be able to write to the application's `tmp/cache` directory. Bootsnap also throws an error that prevents the application from starting up. Deleting it's cache and letting it be rebuilt as the application is used resolves this.

# What's the changes? (:star:)
* Makes `(application_root)/tmp/cache` writable
* Deletes bootsnap cache before initial startup

# How should this be tested?
* Build Geoblacklight application using `geoblacklight_update` branch of Installscripts and `updated` branch of vtul/geoblacklight
* Ensure that the application will load in browser. (More thorough application testing can be handled in the vtul/geoblacklight update PR to come)

# Additional Notes:
* Branches: 
  * Installscripts: `geoblacklight_update`
  * VTUL/geoblacklight: `updated`

# Interested parties
@pmather 

(:star:) Required fields
